### PR TITLE
add scrolling to latest images view

### DIFF
--- a/src/components/ImageView.vue
+++ b/src/components/ImageView.vue
@@ -24,7 +24,7 @@
 
     <!--div class="column is-narrow recent_images"-->
     <div class="recent_images">
-
+       
         <div 
             class="recent_image" 
             style="display: flex;"
@@ -41,7 +41,7 @@
             >
             <!--p style="padding-left: 5px;">{{item.filename.slice(-13)}}</p-->
         </div>
-            
+          
     </div>
     </div></div>
 </template>
@@ -284,7 +284,9 @@ export default {
 }
 
 .recent_images {
-    display: flex;
+    display: flex; 
+    flex-wrap: nowrap;
+    overflow-x: auto;
     flex-direction:row;
     border-top: 1px solid white;
     padding-top: 2em;
@@ -295,6 +297,7 @@ export default {
     margin: 5px;
     margin-left: 0;
     cursor: pointer;
+    flex: 0 0 auto;
 }
 .selected_thumbnail {
     border: 2px solid gold;

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -28,7 +28,7 @@ const actions = {
 
         let site = rootState.observatory_configuration.selected_site;
         let apiName = 'ptr-api';
-        let querySize = 10; // How many images to get
+        let querySize = 40; // How many images to get
         let path = `/${site}/latest_images/${querySize}/`;
 
         /**


### PR DESCRIPTION
Add horizontal scrolling for latest images view in the ImageView component. Cap the maximum number of images available at 40 for now to minimize page loading times. This also affects the table displaying the latest images, which will cap at 40 as well. 