### PR TITLE
Get site events from photonranch-api instead of config

### DIFF
--- a/src/components/CreateProjectForm.vue
+++ b/src/components/CreateProjectForm.vue
@@ -9,8 +9,6 @@
                     <b-input class="project-input" v-model="project_name"></b-input>
                 </b-field>
 
-
-
      <b-tabs type="is-boxed">
 
         <b-tab-item label="Targets">

--- a/src/components/CreateProjectForm.vue
+++ b/src/components/CreateProjectForm.vue
@@ -74,6 +74,7 @@
                             <option value="skyflat"> skyflat </option>
                             <option value="screenflat"> screenflat </option>
                             <option value="bias"> bias </option>
+                            <option value="autofocus"> autofocus </option>
                         </b-select>
                     </b-field>
                     <b-field :label="n==1 ? 'Count' : ''" style="width: 130px;">
@@ -168,8 +169,17 @@
                 </b-field>
                 <b-field 
                     v-if="showAdvancedInputs"
+                    label="Meridian Flip">
+                    <b-checkbox v-model="noflip">No Flip</b-checkbox>
+                </b-field>
+                <b-field 
+                    v-if="showAdvancedInputs"
                     label="Autofocus">
                     <b-checkbox v-model="frequent_autofocus">focus more frequently</b-checkbox>
+                </b-field>
+                <b-field 
+                    v-if="showAdvancedInputs" >
+                    <b-checkbox v-model="near_tycho_star">Use Near Tycho Star</b-checkbox>
                 </b-field>
                 <b-field 
                     v-if="showAdvancedInputs"
@@ -314,7 +324,9 @@ export default {
                 },
             ],
 
+            noflip: false,
             frequent_autofocus: false,
+            near_tycho_star: false,
 
             prefer_bessell: false,
             max_airmass: 2.0,
@@ -487,7 +499,9 @@ export default {
                     lunar_dist_min: this.lunar_dist_min,
                     lunar_phase_max: this.lunar_phase_max,
                     enhance_photometry: this.enhance_photometry,
+                    noflip: this.noflip,
                     frequent_autofocus: this.frequent_autofocus,
+                    use_tycho_star: this.use_tycho_star,
                     pa: this.pa,
                     
                 },

--- a/src/components/SiteEventsModal.vue
+++ b/src/components/SiteEventsModal.vue
@@ -100,9 +100,7 @@ export default {
     },
     data() {
         return {
-            //site_events: [{} * 26],
             site_events: JSON.parse(window.localStorage.getItem(`${this.sitecode}Events`)) || [],
-
             time_display_format: "user", // 'user' or 'observatory',
         }
     },
@@ -113,11 +111,9 @@ export default {
             site_events = site_events.data
 
             // Function to convert from dublin julian days to unix time
-            let djd2unix = t => (t-25567.5)*86400*1000
+            // Subtract difference in JD start vs unix start, then mulitply by 
+            // the number of miliseconds in a day.
             let jd2unix = t => (t - 2440587.5) * 86400 * 1000
-            //(djd + 2415020 - 2440587.5) × 86400 = unix time (s)
-
-            console.log(site_events)
 
             let tableData = []
 

--- a/src/components/SiteHome.vue
+++ b/src/components/SiteHome.vue
@@ -8,9 +8,11 @@
 
     <div class="spacer" style="height: 2em;" />
 
+    <!-- Dome camera -->
     <the-dome-cam v-if="sitecode=='wmd'"/>
     <br>
 
+    <!-- Site events modal window -->
     <div style="display:flex; margin-bottom: 1em;">
         <h3 class="subtitle">Site Events: </h3>
         <div style="width: 10px;"/>
@@ -21,7 +23,6 @@
         </button>
         <b-modal :active.sync="siteEventsVisible">
             <site-events-modal 
-                :site-events="siteEventsTable" 
                 :sitecode="sitecode"/>
         </b-modal>
     </div>
@@ -31,11 +32,9 @@
         :latitude="latitude"
         :longitude="longitude"
     ></leaflet-map-->
-
     <div style="width: 100%; height: 500px; margin-bottom: 1em;">
         <iframe style="width: 100%; height: 100%;" :src="`https://embed.windy.com/embed2.html?lat=${latitude}&lon=${longitude}&zoom=7&level=surface&overlay=clouds&menu=&message=&marker=true&calendar=now&pressure=&type=map&location=coordinates&detail=&detailLat=${latitude}&detailLon=${longitude}&metricWind=m%2Fs&metricTemp=%C2%B0C&radarRange=-1`" frameborder="0"></iframe>
     </div>
-
 
     <!-- This is a temporary solution only. Does not scale. -->
     <!-- Add ClearDarkSky charts to site homepage -->
@@ -66,6 +65,7 @@ import { commands_mixin } from '../mixins/commands_mixin'
 import LeafletMap from '@/components/LeafletMap'
 import SiteEventsModal from '@/components/SiteEventsModal'
 import moment from 'moment'
+import axios from 'axios'
 
 export default {
     name: "SiteHome",
@@ -79,7 +79,7 @@ export default {
     },
     data() {
         return {
-            siteEventsVisible: false
+            siteEventsVisible: false,
         }
     },
     computed: {
@@ -88,24 +88,6 @@ export default {
 
         latitude() { return this.site_config(this.sitecode).latitude },
         longitude() { return this.site_config(this.sitecode).longitude },
-
-        siteEventsTable() {
-            let djd2unix = t => (t-25567.5)*86400*1000
-            //(djd + 2415020 - 2440587.5) × 86400 = unix time (s)
-            let tableData = []
-            let events = this.site_config(this.sitecode).events
-            console.log(this.site_config(this.sitecode).events)
-            for (const property in events) {
-                let time = moment(djd2unix(events[property]))
-                tableData.push({
-                    key: property.toLowerCase(),
-                    time: time.format('HH:mm'),
-                    date: time.format('MM-DD . . . HH:mm'),
-                    unix: time.unix(),
-                })
-            }
-            return tableData
-        },
     }
     
     

--- a/src/components/TheCalendar.vue
+++ b/src/components/TheCalendar.vue
@@ -121,7 +121,7 @@ TODO:
   - save events in UTC so that modifications are possible from any timezone.
     (currently appending -8:00 to indicate PST )
 
-  - retrieve site lat/lon in the twighlight calculator. Don't hardcode!
+  - retrieve site lat/lon in the twilight calculator. Don't hardcode!
 
   - set min/max time (start/end) to a few hours before dusk.
     use utc offset + site tz offset 
@@ -191,8 +191,8 @@ export default {
         // Return the list of sources that feed fullCalendar with events
         fc_eventSources() {
             return [
-                // Astronomical twighlight events (computed locally)
-                { events: this.getTwighlightEvents },
+                // Astronomical twilight events (computed locally)
+                { events: this.getTwilightEvents },
                 // Events from dynamodb backend
                 { events: this.fetchSiteEvents },
                 // Now Indicator
@@ -324,7 +324,7 @@ export default {
           this.isLoading = val; 
         },
 
-        async getTwighlightEvents(info) {
+        async getTwilightEvents(info) {
 
             // Timer start
             let t0=performance.now()
@@ -348,9 +348,9 @@ export default {
 
             //console.log('allDays: ', allDays)
 
-            // Generate the twighlight events (in proper fullCalendar format)
+            // Generate the twilight events (in proper fullCalendar format)
             // for one day column (evening-of and morning-after the given date.)
-            function oneDayTwighlight(timestamp, latitude, longitude) {
+            function oneDayTwilight(timestamp, latitude, longitude) {
 
                 let events = {}
 
@@ -384,24 +384,24 @@ export default {
                     //backgroundColor: daylightColor,
                     //id: `${currentDateObj.toISOString()}_day_afternoon`,
                 //}
-                events.civilTwighlightDusk = {
-                    title: "Civil Twighlight",
+                events.civilTwilightDusk = {
+                    title: "Civil Twilight",
                     start: sunEvents.sunset,
                     end: sunEvents.dusk,
                     backgroundColor: civilColor,
                     rendering: "background",
                     id: `${currentDateObj.toISOString()}_civil_dusk`,
                 }
-                events.nauticalTwighlightDusk = {
-                    title: "Nautical Twighlight",
+                events.nauticalTwilightDusk = {
+                    title: "Nautical Twilight",
                     start: sunEvents.dusk,
                     end: sunEvents.nauticalDusk,
                     backgroundColor: nauticalColor,
                     rendering: "background",
                     id: `${currentDateObj.toISOString()}_nautical_dusk`,
                 }
-                events.astronomicalTwighlightDusk = {
-                    title: "Astronomical Twighlight",
+                events.astronomicalTwilightDusk = {
+                    title: "Astronomical Twilight",
                     start: sunEvents.nauticalDusk,
                     end: sunEvents.night,
                     backgroundColor: astronomicalColor,
@@ -409,24 +409,24 @@ export default {
                     id: `${currentDateObj.toISOString()}_astronomical_dusk`,
                 }
 
-                events.astronomicalTwighlightDawn = {
-                    title: "Astronomical Twighlight",
+                events.astronomicalTwilightDawn = {
+                    title: "Astronomical Twilight",
                     start: nextDayEvents.nightEnd,
                     end: nextDayEvents.nauticalDawn,
                     backgroundColor: astronomicalColor,
                     rendering: "background",
                     id: `${currentDateObj.toISOString()}_astronomical_dawn`,
                 }
-                events.nauticalTwighlightDawn = {
-                    title: "Nautical Twighlight",
+                events.nauticalTwilightDawn = {
+                    title: "Nautical Twilight",
                     start: nextDayEvents.nauticalDawn,
                     end: nextDayEvents.dawn,
                     backgroundColor: nauticalColor,
                     rendering: "background",
                     id: `${currentDateObj.toISOString()}_nautical_dawn`,
                 }
-                events.civilTwighlightDawn = {
-                    title: "Civil Twighlight",
+                events.civilTwilightDawn = {
+                    title: "Civil Twilight",
                     start:nextDayEvents.dawn,
                     end:nextDayEvents.sunrise,
                     backgroundColor: civilColor,
@@ -446,15 +446,15 @@ export default {
             }
 
             // Collect all the events to display here
-            let twighlightEvents = []
+            let twilightEvents = []
 
             let site_lat = parseFloat(this.site_config(this.calendarSite)['latitude'])
             let site_lng = parseFloat(this.site_config(this.calendarSite)['longitude'])
 
 
             // Compute events for each day. 
-            allDays.map((day) => twighlightEvents.push(...Object.values(
-              oneDayTwighlight(
+            allDays.map((day) => twilightEvents.push(...Object.values(
+              oneDayTwilight(
                 day, 
                 site_lat,
                 site_lng,
@@ -463,11 +463,11 @@ export default {
 
             // Finish timer
             let t1=performance.now()
-            let twighlightComputeTime = t1-t0
-            if (twighlightComputeTime > 100) {
-                console.warn('Slow computation of astro twighlight: ', twighlightComputeTime.toFixed(2)+'ms')
+            let twilightComputeTime = t1-t0
+            if (twilightComputeTime > 100) {
+                console.warn('Slow computation of astro twilight: ', twilightComputeTime.toFixed(2)+'ms')
             }
-            return twighlightEvents
+            return twilightEvents
         },
 
         async getConfigWithAuth() {

--- a/src/components/TheWorldMap.vue
+++ b/src/components/TheWorldMap.vue
@@ -242,7 +242,7 @@ export default {
 
     // Draw the daylight regions, and update every few seconds.
     nite.init(this.map)
-    this.updateTwighlightInterval = setInterval(function () { nite.refresh() }, 10000) // every 10s
+    this.updateTwilightInterval = setInterval(function () { nite.refresh() }, 10000) // every 10s
 
     // Get position of the sun and display on map, and update every few seconds.
     this.drawSunMarker()
@@ -251,7 +251,7 @@ export default {
   },
   beforeDestroy() {
     // Remove the looping intervals that update the sun and daylight regions on the map.
-    clearInterval(this.updateTwighlightInterval)
+    clearInterval(this.updateTwilightInterval)
     clearInterval(this.updateSunInterval)
     clearInterval(this.updateSiteColorInterval)
   },


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/173955139
Demo: http://dev.photonranch.org/site/saf/home

The primary task in this PR is to fetch observatory sky events from the backend service in photonranch-api instead of the site config file. 

I also moved some of the logic into the display component. Previously, the data was obtained by the parent and passed in as a prop, but I think this new structure is cleaner. The time column is now sorted to show utc and the local time for the observatory or the user (based on their computer clock). 

The last few changes (from before this sprint cycle) showcase the moment I realized how to spell 'twilight'.

The following screenshot shows the display that you can also find at the demo link included at the top. Next to 'Site Events' in the middle of the page, click the button that says 'show'.
![Screenshot from 2020-08-12 15-01-01](https://user-images.githubusercontent.com/35314207/90073062-5dd64d80-dcad-11ea-9950-04af7fac0905.png)
