### PR TITLE
Feature/misc tasks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@ import JS9 from "@/components/JS9";
 export default {
   components: { JS9 },
   beforeCreate() {
-    // Initial load of the config. This is the only time it needs to happen unless the user relaods the site. 
+    // Initial load of the config. This is the only time it needs to happen unless the user reloads the site. 
     this.$store.dispatch('site_config/update_config')
   },
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,34 +1,24 @@
 <template>
   <div id="app">
-
-    <router-view class="router-view"></router-view>
+    <router-view class="router-view" v-if="$store.state.site_config.did_config_load_yet" />
 
     <!-- This is the home for the JS9 DOM elements. They are hidden here and only 
-    visible when moved into the js9 component. This avoid js9-reloading issues. -->
+    visible when moved into the js9 component. This avoid js9-reloading issues.-->
     <div id="js9home" ref="js9home" v-show="false">
       <div id="js9content" ref="js9content">
-        <div class="JS9Menubar" id="myJS9Menubar" ></div>
+        <div class="JS9Menubar" id="myJS9Menubar"></div>
         <div class="JS9" id="myJS9" data-js9init="true"></div>
       </div>
     </div>
-
-
   </div>
 </template>
 
 <script>
-import SiteNavbar from '@/components/SiteNavbar.vue'
 import JS9 from "@/components/JS9";
-import axios from 'axios'
-
- 
 export default {
-  name: 'App',
-  components: {
-    SiteNavbar,
-    JS9,
-  },
-  async created() {
+  components: { JS9 },
+  beforeCreate() {
+    // Initial load of the config. This is the only time it needs to happen unless the user relaods the site. 
     this.$store.dispatch('site_config/update_config')
   },
 }
@@ -37,7 +27,6 @@ export default {
 <style scoped lang="scss">
 .router-view {
   height: calc(100vh - 75px);
-  //overflow-y: scroll;
-  overflow-x:hidden;;
+  overflow-x: hidden;
 }
 </style>

--- a/src/components/SitesOverviewCards.vue
+++ b/src/components/SitesOverviewCards.vue
@@ -1,5 +1,4 @@
 <template>
-  <div>
   <div class="card-row">
     <template v-for="s in all_sites_real">
       <div 
@@ -22,43 +21,8 @@
             <figure class="image is-2by1"> <img :src="site_images[s.site]" /> </figure>
           </router-link>
         </div>
-
       </div>
     </template>
-  </div>
-
-  <hr class="divider"/>
-
-  <div class="card-row">
-    <template v-for="s in all_sites_simulated">
-      <div 
-        :key="s.site" 
-        :val="s.site"
-        v-if="!site_blacklist.includes(s.site)"
-        class="card" 
-        :class="{
-          'online': isOnline(s.site)
-          }">
-
-        <div class="card-header subtitle">
-          <router-link :to="'/site/'+s.site+'/observe'">
-            <span style="color: white; height: 2em;">{{s.name}}</span>
-          </router-link>
-        </div>
-
-        <div class="card-image">
-          <router-link :to="'/site/'+s.site+'/observe'">
-            <figure class="image is-2by1"> <img :src="site_images[s.site]" /> </figure>
-          </router-link>
-        </div>
-
-      </div>
-    </template>
-    <!-- add empty test sites so the cards are sized the same as the real sites -->
-    <template v-for="index in empty_test_sites_needed">
-      <div :key="index" class="card-placeholder" />
-    </template>
-  </div>
   </div>
 </template>
 

--- a/src/components/calendar/CalendarEventEditor.vue
+++ b/src/components/calendar/CalendarEventEditor.vue
@@ -15,7 +15,7 @@
             v-model="title"
             placeholder="Add a name for your reservation"
             required
-            validation-message="Please include a title"
+            validation-message="Please include a name for your reservation"
             ref="title_input"
         >{{title}}</b-input>
     </b-field>
@@ -194,8 +194,6 @@ export default {
 
             real_time_session_duration: 30,
             reservation_type_tabs: 'realtime',
-
-            no_title_warning:true,
 
             show_everyones_projects: false,
 

--- a/src/components/calendar/SiteReservationStatus.vue
+++ b/src/components/calendar/SiteReservationStatus.vue
@@ -1,0 +1,137 @@
+<template>
+  <div>
+    <!-- Show whether a site is currently reserved or not -->
+    <div class="site-reservation-status-box">
+      <!-- Display if there are no current reservations -->
+      <div v-if="!hasActiveReservation">
+        <p class="menu-label site-not-reserved-notice">
+          no active reservations
+        </p>
+        <p>Next in: 0h 0m</p>
+        <p style="color: #555">(timer not implemented)</p>
+        <div style="height: 5px" />
+      </div>
+
+      <!-- Display if the site is currently reserved for use (and not by current user). -->
+      <div v-if="hasActiveReservation && !userHasActiveReservation">
+        <p class="menu-label site-reserved-notice">Site is reserved</p>
+        <p>Remaining: {{ timeRemainingForSoonestCurrentReservation }}</p>
+      </div>
+
+      <!-- Display if the site is currently reserved by the active user -->
+      <div v-if="userHasActiveReservation">
+        <p class="menu-label site-reserved-current-user">Reserved for you</p>
+        <p>Remaining: {{ userReservationTimeRemaining }}</p>
+      </div>
+
+      <div style="height: 5px" />
+      <router-link :to="`/site/${sitecode}/calendar`">
+        <b-button size="is-small" class="button is-dark" icon-right="calendar"
+          >view calendar</b-button
+        >
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapState } from "vuex";
+import moment from "moment";
+export default {
+  name: "SiteReservationStatus",
+  props: ["sitecode"],
+  data() {
+    return {
+      current_time_millis: moment().valueOf(),
+      current_time_millis_updater: "", // setInterval object
+    };
+  },
+  created() {
+    // Update current_time_millis every second. For reservation countdown.
+    this.current_time_millis_updater = setInterval(() => {
+      this.current_time_millis = moment().valueOf();
+    }, 1000);
+  },
+  beforeDestroy() {
+    clearTimeout(this.current_time_millis);
+  },
+  watch: {
+    sitecode: function () {
+      // Refresh the active reservations list for the new site.
+      this.$store.dispatch("calendar/fetchActiveReservations", this.sitecode);
+    },
+  },
+  computed: {
+    ...mapState("calendar", ["active_reservations"]),
+    ...mapGetters("calendar", [
+      "hasActiveReservation",
+      "usersWithActiveReservation",
+      "userIDsWithActiveReservation",
+      "endOfUserReservation",
+      "endOfNextReservation",
+    ]),
+    userHasActiveReservation() {
+      if (this.$auth.isAuthenticated) {
+        let user_id = this.$auth.user.sub;
+        return this.userIDsWithActiveReservation.includes(user_id);
+      } else {
+        return false;
+      }
+    },
+    timeRemainingForSoonestCurrentReservation() {
+      let expire_time = this.endOfNextReservation;
+      let current_time = this.current_time_millis;
+      let delta = expire_time - current_time;
+      let millis_per_minute = 60 * 1000;
+      let millis_per_hour = 3600 * 1000;
+      let hours_left = Math.floor(delta / millis_per_hour);
+      let minutes_left = Math.floor(
+        (delta - hours_left * millis_per_hour) / millis_per_minute
+      );
+      return `${hours_left}h ${minutes_left}m`;
+    },
+    userReservationTimeRemaining() {
+      if (this.$auth.isAuthenticated) {
+        let user_id = this.$auth.user.sub;
+        let expire_time = this.endOfUserReservation(user_id);
+        let current_time = this.current_time_millis;
+        let delta = expire_time - current_time;
+        let millis_per_minute = 60 * 1000;
+        let millis_per_hour = 3600 * 1000;
+        let hours_left = Math.floor(delta / millis_per_hour);
+        let minutes_left = Math.floor(
+          (delta - hours_left * millis_per_hour) / millis_per_minute
+        );
+        return `${hours_left}h ${minutes_left}m`;
+      } else {
+        return "0h 0m";
+      }
+    },
+    // Get the username from Auth0
+    username() {
+      if (this.$auth.isAuthenticated) {
+        return this.$auth.user.name;
+      }
+      return "anonymous";
+    },
+  },
+};
+</script>
+
+
+<style lang="scss" scoped>
+@import "@/style/buefy-styles.scss";
+.site-not-reserved-notice {
+  color: $info;
+}
+.site-reserved-notice {
+  color: yellow;
+}
+.site-reserved-current-user {
+  color: greenyellow;
+}
+.site-reservation-status-box {
+    border: 2px silver;
+    border-radius: 8px;
+}
+</style>

--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -779,7 +779,7 @@ export default {
     newEventSelected(event) {
       this.activeEvent.startStr = moment(event.startStr).utc().format();
       this.activeEvent.endStr = moment(event.endStr).utc().format();
-      this.activeEvent.title = "";
+      this.activeEvent.title = this.$auth.user.name;
       this.activeEvent.reservation_type = "realtime" // or "project"
       this.activeEvent.creator = this.$auth.user.name;
       this.activeEvent.id = this.makeUniqueID();

--- a/src/components/maps/TheWorldMap.vue
+++ b/src/components/maps/TheWorldMap.vue
@@ -109,8 +109,6 @@ export default {
       function iwClose() { iw.close(); }
       google.maps.event.addListener(this.map, 'click', iwClose);
 
-      console.log(sites.map(s => s.site))
-
       const markers = sites.filter(site => {
         // First, remove sites that don't have an available status 
         return Object.keys(this.site_open_status).includes(site.site)

--- a/src/components/sitepages/SiteCalendar.vue
+++ b/src/components/sitepages/SiteCalendar.vue
@@ -41,6 +41,7 @@
 <script>
 import TheCalendar from "@/components/calendar/TheCalendar";
 import UserEventsTable from "@/components/calendar/UserEventsTable";
+import SiteReservationStatus from "@/components/calendar/SiteReservationStatus";
 import { mapState, mapGetters } from "vuex";
 import axios from "axios";
 import moment from "moment";
@@ -51,6 +52,7 @@ export default {
   components: {
     TheCalendar,
     UserEventsTable,
+    SiteReservationStatus,
   },
   data() {
     return {

--- a/src/components/sitepages/SiteCalendar.vue
+++ b/src/components/sitepages/SiteCalendar.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="cal-page-wrapper">
 
-
     <the-calendar 
       class="the-calendar"
       v-if="timezone"
@@ -32,8 +31,6 @@
       </div>
 
     </div>
-    <!--button class="button" @click="getUserEvents">get user events</button-->
-
   </div>
 </template>
 
@@ -42,8 +39,7 @@
 import TheCalendar from "@/components/calendar/TheCalendar";
 import UserEventsTable from "@/components/calendar/UserEventsTable";
 import SiteReservationStatus from "@/components/calendar/SiteReservationStatus";
-import { mapState, mapGetters } from "vuex";
-import axios from "axios";
+import { mapGetters } from "vuex";
 import moment from "moment";
 
 export default {

--- a/src/components/status/PhaseStatusBar.vue
+++ b/src/components/status/PhaseStatusBar.vue
@@ -3,7 +3,7 @@
     <div class="container phase-status-wrapper">
         <div class="phase-status-title">
             <span>Next Events: </span>
-            <span class="timestamp">{{phase_status_sorted[0].timestamp | readable_date}}</span>
+            <span class="timestamp">{{phase_status_sorted[0]?.timestamp | readable_date}}</span>
         </div> 
         <template v-for="(s, index) in phase_status_sorted">
             <span :key="index + 'spacer'" class="spacer" v-if="index"> | </span>
@@ -48,7 +48,8 @@ export default {
     filters: {
         readable_date(timestamp) {
             // don't forget to convert back to ms for js date handling
-            return moment(timestamp * 1000).format("MM/DD HH:mm:ss");
+            let readable = moment(timestamp * 1000).format("MM/DD HH:mm:ss");
+            return readable
         }
     },
     created() {
@@ -92,7 +93,9 @@ export default {
                 + `/phase_status/${this.site}`
                 + `?max_age_seconds=${encodeURIComponent(max_age)}`
             let latest_phase_status = await axios.get(url)
-            this.phase_status = latest_phase_status.data
+            if (latest_phase_status.data.length) {
+                this.phase_status = latest_phase_status.data
+            }
         },
         text_opacity_style(timestamp) {
             const hour = 60 * 60

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -290,7 +290,6 @@ const actions = {
          */
         axios.get(apiName+path).then(async response => {
             response = response.data
-            console.log(response)
 
             // Empty response:
             if (response.length == 0) { 

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -70,10 +70,16 @@ const getters = {
       return sites
     },
     all_sites_real: (state, getters) => {
-      return getters.all_sites.filter(s => !state.test_sites.includes(s.site.toLowerCase()))
+        let sites = getters.all_sites.filter(s => !state.test_sites.includes(s.site.toLowerCase()))
+        // sort by longitude
+        sites = sites.sort((a, b) => a.longitude - b.longitude)
+        return sites
     },
     all_sites_simulated: (state, getters) => {
-      return getters.all_sites.filter(s => state.test_sites.includes(s.site.toLowerCase()))
+        let sites = getters.all_sites.filter(s => state.test_sites.includes(s.site.toLowerCase()))
+        // sort by longitude
+        sites = sites.sort((a, b) => a.longitude - b.longitude)
+        return sites
     },
 
     selected_enclosure_config: (state, getters) => {

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -10,7 +10,7 @@ const state = {
 
     test_sites: ['tst', 'tst001', 'dht', 'sintezsim'],
 
-    global_config: JSON.parse(window.localStorage.getItem('global_config') || '{}'),
+    global_config: {},
     is_site_selected: false,
     did_config_load_yet: false,
 
@@ -245,10 +245,8 @@ const actions = {
      * observatories in the network. 
      */
     update_config({ commit, dispatch, rootState }) {
-        let apiName = rootState.dev.active_api;
-        let path = '/all/config/';
-        return axios.get(apiName+path).then(response => {
-            window.localStorage.setItem('global_config', JSON.stringify(response.data))
+        const url = `${rootState.dev.active_api}/all/config`
+        axios.get(url).then(response => {
             commit('setGlobalConfig', response.data)
         }).catch(error => {
             console.warn(error)

--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -27,9 +27,6 @@
     </div>
 
     <div class="page-view">
-        <!-- Primary content of the page. Selects from the various site subpages. -->
-        <!-- Note: wait for parent (this component) to mount before loading child components. 
-        Otherwise, props may initially load as null. -->
         <component v-bind:is="`site-${subpage}`" :sitecode="sitecode" />
     </div>
 


### PR DESCRIPTION
This is a bunch of small tasks mostly pulled from trello. 

The biggest change is an update to the way the config files are loaded from the server. There used to be a bug where directly loading a site page (e.g. /site/mrc/observe) threw errors and showed a blank page until reloading because the config did not arrive before components tried to use it to render. Now, the config is loaded once in the top level App.vue, and rendering the router component waits until the config is loaded.

Additional changes:
- The form to create calendar events uses the username as a default event name rather than an empty default
- Simulation/test sites are removed from the list of cards on the homepage (but not the map)
- Site cards on the homepage are sorted by longitude
- Removed an error for the phase status that happens when the server has nothing to display yet
- Added back SiteReservationStatus.vue that was accidentally removed earlier during a cleaning session