### PR TITLE
Add form for users to restart a site

### DIFF
--- a/src/components/DownloadInterface.vue
+++ b/src/components/DownloadInterface.vue
@@ -41,10 +41,7 @@ export default {
     DatetimeWithTimezonePicker,
   },
   props: {
-    site: {
-      type: String,
-      required: true,
-    },
+    site: String
   },
   data() {
     return {

--- a/src/components/FormElements/DatetimeWithTimezonePicker.vue
+++ b/src/components/FormElements/DatetimeWithTimezonePicker.vue
@@ -41,7 +41,7 @@
 import { utc_offset_from_coordinates } from '@/utils/timezones'
 import { mapState, mapGetters } from 'vuex'
 export default {
-    name: 'DownloadInterface',
+    name: 'DatetimeWithTimezonePicker',
     props: {
         size: {
             type: String,
@@ -51,13 +51,8 @@ export default {
             },
             default: () => ''
         },
-        site: {
-            type: String,
-            default: () => '',
-        },
-        label: {
-            type: String
-        },
+        site: String,
+        label: String,
         date: {
             type: Date,
             default: () => new Date()

--- a/src/components/SiteRestartCommand.vue
+++ b/src/components/SiteRestartCommand.vue
@@ -1,0 +1,160 @@
+
+<template>
+  <div>
+    <b-button :size="size" @click="restart_modal_is_active = true" >Restart Site</b-button >
+    <b-modal :active.sync="restart_modal_is_active">
+      <div class="card">
+        <header class="modal-card-head">
+          <p class="modal-card-title">
+            Restart Site:
+            <span class="modal-site-name">&nbsp;{{ site.toUpperCase() }}</span>
+          </p>
+          <button
+            type="button"
+            class="delete"
+            @click="restart_modal_is_active = false"
+          />
+        </header>
+        <section class="modal-card-body">
+          <b-field label="Please say why you would like to restart">
+            <b-input
+              type="text"
+              v-model="user_provided_reason"
+              :disabled="not_logged_in"
+              :value="user_provided_reason"
+            >
+            </b-input>
+          </b-field>
+        </section>
+        <footer class="modal-card-foot">
+          <b-button
+            label="Restart"
+            :disabled="user_provided_reason.length == 0 || not_logged_in"
+            :class="{ 'is-loading': is_loading }"
+            @click="send_command"
+            type="is-primary"
+          />
+        <p class='login-warning' v-if="!$auth.isAuthenticated">
+            You need to be logged in to do this
+        </p>
+        </footer>
+      </div>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+import { mapGetters } from "vuex";
+import { commands_mixin } from "@/mixins/commands_mixin";
+import { getInstance } from "@/auth/index"; // get user object: getInstance().user
+
+export default {
+  name: "SiteRestartCommand",
+  mixins: [commands_mixin],
+  props: {
+    site: {
+      type: String,
+      required: true,
+    },
+    isDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    // Used to set the modal trigger button size
+    size: {
+      type: String,
+      default: "is-small",
+    },
+    admin: {
+      type: Boolean,
+    },
+  },
+  data() {
+    return {
+      is_loading: false,
+      restart_modal_is_active: false,
+      user_provided_reason: "",
+    };
+  },
+  methods: {
+    async send_command() {
+      this.is_loading = true;
+
+      const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.site}`;
+      const options = await this.getAuthHeader();
+      axios
+        .post(url, this.restart_command_body, options)
+        .then((response) => {
+          this.is_loading = false;
+          console.log("command response: ", response.data);
+          this.$emit("jobPost", response.data);
+        })
+        .catch((error) => {
+          this.is_loading = false;
+          console.log(error);
+          this.handleNotAuthorizedResponse(error);
+        })
+        .finally(() => {
+          this.restart_modal_is_active = false;
+        });
+    },
+  },
+  computed: {
+    ...mapGetters("auth", {
+      token: "getToken",
+    }),
+    not_logged_in() {
+        return !this.$auth.isAuthenticated
+    },
+    username() {
+      return getInstance().user?.name ?? "anonymous";
+    },
+    user_id() {
+      return getInstance().user?.sub ?? "anonymous";
+    },
+    user_roles() {
+      try {
+        let user = this.$auth.user;
+        let roles = user["https://photonranch.org/user_metadata"].roles;
+        return roles;
+      } catch {
+        return [];
+      }
+    },
+
+    restart_command_body() {
+      return {
+        site: this.site,
+        action: "site_restart",
+        device: "all",
+        instance: "all",
+        user_name: this.username,
+        user_id: this.user_id,
+        user_roles: this.user_roles,
+        timestamp: parseInt(Date.now() / 1000),
+        required_params: {
+          user_provided_reason: this.user_provided_reason,
+        },
+        optional_params: {},
+      };
+    },
+
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+@import "@/style/_variables.scss";
+.is-admin {
+  background-color: rgba(68, 0, 255, 0.164);
+  border-color: rgba(76, 0, 255, 0.541);
+}
+.modal-site-name {
+  color: $grey-light;
+  font: 20px "Share Tech Mono", monospace;
+}
+.login-warning {
+    color: #f1b70e;
+}
+</style>

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -297,7 +297,10 @@ export default {
     RecentS3UploadsTable,
     SiteConfigViewer,
     DownloadInterface,
-    FitsHeaderModal
+    FitsHeaderModal,
+  },
+  props: {
+    sitecode: String
   },
   data() {
     return {
@@ -451,9 +454,6 @@ export default {
   },
 
   computed: {
-    sitecode() {
-      return this.$route.params.sitecode
-    },
 
     ...mapState("images", [
       'recent_images',

--- a/src/components/status/SiteStatusFooter.vue
+++ b/src/components/status/SiteStatusFooter.vue
@@ -116,10 +116,12 @@
                 style="padding: 0"
                 :statusList="device_status_display_1"
               />
-              <status-column
-                style="padding: 0"
-                :statusList="device_status_display_2"
-              />
+              <div style="display:flex; flex-direction:column;">
+                <status-column
+                  style="padding: 0"
+                  :statusList="device_status_display_2"/>
+                <SiteRestartCommand :site="site" class="site-restart-button"/>
+              </div>
             </div>
           </div>
 
@@ -218,6 +220,7 @@ import SiteLocalTime from "@/components/display/SiteLocalTime";
 import UtcTime from "@/components/display/UtcTime";
 import SiteOperationalStatus from "@/components/status/SiteOperationalStatus";
 import PhaseStatusBar from '@/components/status/PhaseStatusBar'
+import SiteRestartCommand from '@/components/SiteRestartCommand'
 export default {
   name: "SiteStatusFooter",
   mixins: [ user_status_mixin],
@@ -228,9 +231,12 @@ export default {
     UtcTime,
     SiteOperationalStatus,
     PhaseStatusBar,
+    SiteRestartCommand,
   },
   props: {
-    site: String,
+    site: {
+      type: String,
+    }
   },
 
   data() {
@@ -508,7 +514,7 @@ export default {
  *  Component styling
  */
 .statusbar {
-  z-index: 10;
+  z-index: 40;
 }
 .hidden {
   display: none;
@@ -711,6 +717,17 @@ div.log-line:last-of-type * {
 }
 .pin-icon {
   color: silver;
+}
+
+.site-restart-button {
+  display:flex;
+  flex-direction: row-reverse;
+  border-top: 1px solid silver;
+  width: 100%;
+  margin-left: auto;
+  margin-right: 0;
+  margin-top: 1em;
+  padding-top: 1em;
 }
 
 // Style the status container boxes in the expanded status panel

--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -7,19 +7,19 @@
       <div class="mobile-site-menu">
         <button class="menu-padding"></button>
         <router-link :to="'/site/' + sitecode + '/home'">
-          <button class="button" :class="{'selected': active_subpage == 'home'}">Home</button>
+          <button class="button" :class="{'selected': subpage == 'home'}">Home</button>
         </router-link>
         <router-link :to="'/site/' + sitecode + '/targets'">
-          <button class="button" :class="{'selected': active_subpage == 'targets'}">Targets</button>
+          <button class="button" :class="{'selected': subpage == 'targets'}">Targets</button>
         </router-link>
         <router-link :to="'/site/' + sitecode + '/observe'">
-          <button class="button" :class="{'selected': active_subpage == 'observe'}">Observe</button>
+          <button class="button" :class="{'selected': subpage == 'observe'}">Observe</button>
         </router-link>
         <router-link :to="'/site/' + sitecode + '/calendar'">
-          <button class="button" :class="{'selected': active_subpage == 'calendar'}">Calendar</button>
+          <button class="button" :class="{'selected': subpage == 'calendar'}">Calendar</button>
         </router-link>
         <router-link :to="'/site/' + sitecode + '/projects'">
-          <button class="button" :class="{'selected': active_subpage == 'projects'}">Projects</button>
+          <button class="button" :class="{'selected': subpage == 'projects'}">Projects</button>
         </router-link>
         <button class="menu-padding" button></button>
       </div>
@@ -76,7 +76,16 @@ export default {
     SiteStatusFooterMobile,
     SiteNavbar,
   },
-  props: ["sitecode", "subpage"],
+  props: {
+    sitecode: {
+      type: String,
+      required: true,
+    },
+    subpage: {
+      type: String,
+      required: true,
+    }
+  },
   mixins: [commands_mixin],
 
   // When the site page component loads for the first time, set the current site in vuex. 
@@ -112,10 +121,6 @@ export default {
     setInterval(() => {
       this.timestamp = parseInt(Date.now() / 1000);
     }, 1000);
-  },
-
-  computed: {
-    active_subpage() { return this.$route.params.subpage }
   },
 
   methods: {


### PR DESCRIPTION
This PR addresses the trello request here: https://trello.com/c/hkH7A6JZ
Contents pasted below: 

> I think a good place for this is in the expanded tatus in the lower right-hand corner. The name can be Restart Site. Not Reset or Reboot.
Upon pushing it a dialog should appear: "Please say why you want to do this;" And then a text box. If any character is entered in the box then a Proceed button is enabled and the user can trigger the Re-start, otherwise
the dialog and request are dismissed. I will then enter the time, user and reason in a log.

A few small general syntax/naming changes are included as well. 