### PR TITLE
Feature/misc improvements

### DIFF
--- a/src/components/FormElements/TargetSearchField.vue
+++ b/src/components/FormElements/TargetSearchField.vue
@@ -1,0 +1,95 @@
+<template>
+  <b-field :horizontal="horizontal" :label="label">
+    <b-field>
+      <b-input
+        name="object"
+        type="search"
+        autocomplete="off"
+        :size="size"
+        v-model="object_name"
+        @input="$emit('input', object_name)"
+        @keyup.enter.native="search_for_coordinates"
+      ></b-input>
+      <p class="control">
+        <b-button
+          @click="search_for_coordinates"
+          :class="size"
+          :loading="search_is_loading"
+          ><b-icon icon="magnify" :size="size"
+        /></b-button>
+      </p>
+    </b-field>
+  </b-field>
+</template>
+
+<script>
+import { target_names } from "@/mixins/target_names";
+export default {
+  name: "TargetSearchField",
+  mixins: [target_names],
+  props: {
+    name: {
+      type: String,
+      required: false,
+    },
+    label: {
+      type: String,
+      default: "Object",
+    },
+    size: {
+      type: String,
+      default: () => "",
+    },
+    horizontal: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  model: {
+    prop: "name",
+    event: "input",
+  },
+  data() {
+    return {
+      search_is_loading: false,
+      object_name: this.name,
+    };
+  },
+  watch: {
+    name() {
+      this.object_name = this.name;
+    },
+  },
+  methods: {
+    async search_for_coordinates() {
+      if (this.object_name == "") return;
+      this.search_is_loading = true;
+      let ra, dec, name;
+      let error = true;
+
+      let search_results = await this.get_coordinates_from_object_name(
+        this.object_name
+      );
+      this.search_is_loading = false;
+      if (!search_results.error) {
+        error = false;
+        ra = search_results.ra;
+        dec = search_results.dec;
+        name = search_results.name;
+      } else {
+        this.$buefy.toast.open({
+          message: `Could not resolve object with name ${this.object_name}`,
+          type: "is-danger",
+        });
+      }
+      this.$emit("results", {
+        ra,
+        dec,
+        name,
+        error,
+        searched_name: this.object_name,
+      });
+    },
+  },
+};
+</script>

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -38,11 +38,9 @@
         <p class="control">
           <command-button :data="filter_wheel_command" class="is-small"/>
         </p>
-        <command-button :data="filter_wheel_home_command" style="margin-left: 2em;" class="is-small" />
+        <command-button :data="filter_wheel_home_command" style="margin-left: 1em;" class="is-small" />
       </b-field>
 
-        <div class="buttons has-addons">
-        </div>
     </b-field>
 
     <!--b-field horizontal label="Bin" v-if="camera_can_bin">

--- a/src/components/InstrumentControls/Telescope.vue
+++ b/src/components/InstrumentControls/Telescope.vue
@@ -1,91 +1,100 @@
 
 <template>
   <div class="instrument-control-wrapper">
-
-    <div class="val" 
-      v-if="mount_message.val != '-'">
-      {{mount_message}}
+    <div class="val" v-if="mount_message.val != '-'">
+      {{ mount_message }}
     </div>
-    <div class="val" 
-      v-if="telescope_message.val != '-'">
-      {{telescope_message}}
+    <div class="val" v-if="telescope_message.val != '-'">
+      {{ telescope_message }}
     </div>
 
-    <button class="button" style="width: 100%; margin-bottom: 1rem;" @click="move_telescope_and_expose">Move Telescope and Expose</button>
+    <button
+      class="button"
+      style="width: 100%; margin-bottom: 1rem"
+      @click="move_telescope_and_expose"
+    >
+      Move Telescope and Expose
+    </button>
 
     <b-field>
-      <b-radio-button v-model="telescope_selection"
+      <b-radio-button
+        v-model="telescope_selection"
         size="is-small"
         expanded
-        :native-value="1">
+        :native-value="1"
+      >
         Primary
       </b-radio-button>
-      <b-radio-button v-model="telescope_selection"
+      <b-radio-button
+        v-model="telescope_selection"
         size="is-small"
         expanded
-        :native-value="2">
+        :native-value="2"
+      >
         Aux
       </b-radio-button>
     </b-field>
 
     <div class="columns">
       <status-column
-        style="font-size: 0.8em;"
+        style="font-size: 0.8em"
         class="status-column"
         :statusList="buildTelescopeTabStatus1Shorter"
-        :isOffline="!site_is_online" />
+        :isOffline="!site_is_online"
+      />
       <status-column
-        style="font-size: 0.8em;"
+        style="font-size: 0.8em"
         class="status-column column"
         :isOffline="!site_is_online"
-        :statusList="buildTelescopeTabStatus2"/>
+        :statusList="buildTelescopeTabStatus2"
+      />
     </div>
 
-		<div style="border-bottom: 0.5px solid grey; margin: 1em 0;" />
+    <div style="border-bottom: 0.5px solid grey; margin: 1em 0" />
 
     <b-field horizontal label="Ra/Ha/Az/Long">
       <b-field>
-        <b-input 
-          name="subject" 
-          type="search" 
-          icon-clickable 
-          size="is-small" 
-          v-model="mount_ra" 
-          autocomplete="off"></b-input>
+        <b-input
+          name="subject"
+          type="search"
+          size="is-small"
+          v-model="mount_ra"
+          autocomplete="off"
+        ></b-input>
         <!--p class="control"><span class="button is-static is-small">hrs</span></p-->
       </b-field>
     </b-field>
     <b-field horizontal label="Dec/Alt/Lat">
       <b-field>
-        <b-input 
-          name="subject" 
-          type="search" 
-          icon-clickable 
+        <b-input
+          name="subject"
+          type="search"
           size="is-small"
-          v-model="mount_dec" 
-          autocomplete="off"></b-input>
+          v-model="mount_dec"
+          autocomplete="off"
+        ></b-input>
         <!--p class="control"><span class="button is-static is-small">deg</span></p-->
       </b-field>
     </b-field>
-    <b-field horizontal label="Object">
-      <b-input 
-        name="subject" 
-        type="search" 
-        icon-clickable 
-        size="is-small" 
-        v-model="mount_object" 
-        autocomplete="off"></b-input>
-    </b-field>
-
+    <TargetSearchField
+      label="Object"
+      v-model="mount_object"
+      size="is-small"
+      horizontal
+      @results="handle_coordinate_search_results"
+    />
     <b-field horizontal label="Frame">
-      <b-select placeholder="Select bin" 
-        v-model="telescope_coordinate_frame" size="is-small">
+      <b-select
+        placeholder="Select bin"
+        v-model="telescope_coordinate_frame"
+        size="is-small"
+      >
         <option
           v-for="(frame_option, index) in telescope_coordinate_frame_options"
           v-bind:value="frame_option"
           v-bind:selected="index === 0"
           v-bind:key="index"
-          >
+        >
           {{ frame_option }}
         </option>
       </b-select>
@@ -93,49 +102,63 @@
 
     <b-field>
       <p class="control">
-        <command-button :data="mount_slew_radec_command" 
-          style="margin-bottom: 1em;" class="is-small is-success is-outlined"/>
+        <command-button
+          :data="mount_slew_radec_command"
+          style="margin-bottom: 1em"
+          class="is-small is-success is-outlined"
+        />
       </p>
       <p class="control">
-        <command-button :data="mount_slew_hadec_command" 
-          style="margin-bottom: 1em; border-left-color: #48c774;" class="is-small"/>
+        <command-button
+          :data="mount_slew_hadec_command"
+          style="margin-bottom: 1em; border-left-color: #48c774"
+          class="is-small"
+        />
       </p>
       <p class="control">
-        <command-button :data="mount_slew_azalt_command" 
-          style="margin-bottom: 1em;" class="is-small"/>
+        <command-button
+          :data="mount_slew_azalt_command"
+          style="margin-bottom: 1em"
+          class="is-small"
+        />
       </p>
     </b-field>
 
-    <b-dropdown aria-role="list" style="width: 100%;" size="is-small" scrollable>
-      <button class="button is-small" slot="trigger" style="width: 100%;">
-          <span>Slew to...</span>
-          <b-icon icon="menu-down"></b-icon>
+    <b-dropdown aria-role="list" style="width: 100%" size="is-small" scrollable>
+      <button class="button is-small" slot="trigger" style="width: 100%">
+        <span>Slew to...</span>
+        <b-icon icon="menu-down"></b-icon>
       </button>
       <template
         v-for="(command, idx) in [
-            mount_screenflat_command,
-            mount_skyflat_command,
-            mount_home_command,
-            mount_ngp_command,
-            mount_sgp_command,
-            mount_park_command,
-            mount_raSidDec0_command,
-            mount_stop_command,
-            mount_tracking_on_command,
-            mount_tracking_off_command
-          ]"
-        >
+          mount_screenflat_command,
+          mount_skyflat_command,
+          mount_home_command,
+          mount_ngp_command,
+          mount_sgp_command,
+          mount_park_command,
+          mount_raSidDec0_command,
+          mount_stop_command,
+          mount_tracking_on_command,
+          mount_tracking_off_command,
+        ]"
+      >
         <b-dropdown-item :key="idx" aria-role="listitem">
-          <command-button :data="command" class="dropdown-button-command is-small"/>
+          <command-button
+            :data="command"
+            class="dropdown-button-command is-small"
+          />
         </b-dropdown-item>
       </template>
     </b-dropdown>
 
-    <div style="height: 1em;"/>
+    <div style="height: 1em" />
 
-    <div class="status-toggle-bar" 
-      @click="isExpandedStatusVisible= !isExpandedStatusVisible">
-      {{ isExpandedStatusVisible ? 'collapse status' : 'expand status' }}
+    <div
+      class="status-toggle-bar"
+      @click="isExpandedStatusVisible = !isExpandedStatusVisible"
+    >
+      {{ isExpandedStatusVisible ? "collapse status" : "expand status" }}
     </div>
 
     <pre v-if="isExpandedStatusVisible">
@@ -148,105 +171,144 @@
         device_type="Telescope" 
         :device_status="telescope_state" />
     </pre>
-
   </div>
 </template>
 
 <script>
-import { commands_mixin } from '../../mixins/commands_mixin'
-import { user_mixin } from '../../mixins/user_mixin'
-import CommandButton from '@/components/FormElements/CommandButton'
-import StatusColumn from '@/components/status/StatusColumn'
-import SimpleDeviceStatus from '@/components/status/SimpleDeviceStatus'
-import { mapGetters } from 'vuex'
-import { ToastProgrammatic as Toast } from 'buefy'
+import { commands_mixin } from "@/mixins/commands_mixin";
+import { target_names } from "@/mixins/target_names";
+import { user_mixin } from "@/mixins/user_mixin";
+import CommandButton from "@/components/FormElements/CommandButton";
+import StatusColumn from "@/components/status/StatusColumn";
+import SimpleDeviceStatus from "@/components/status/SimpleDeviceStatus";
+import { mapGetters } from "vuex";
+import { ToastProgrammatic as Toast } from "buefy";
+import TargetSearchField from "@/components/FormElements/TargetSearchField";
 export default {
   name: "Telescope",
-  mixins: [commands_mixin, user_mixin],
+  mixins: [commands_mixin, user_mixin, target_names],
   components: {
-    CommandButton, 
+    CommandButton,
     StatusColumn,
     SimpleDeviceStatus,
+    TargetSearchField,
   },
   data() {
     return {
       isExpandedStatusVisible: false,
-    }
+      object_is_searching: false,
+      object_search_input: "",
+    };
   },
 
   methods: {
-
     move_telescope_and_expose() {
       if (!this.mount_ra) {
         this.$buefy.toast.open({
-          message: 'Please specify a right ascension to point the telescope',
-          type: 'is-danger'
-        })
+          message: "Please specify a right ascension to point the telescope",
+          type: "is-danger",
+        });
       }
       if (!this.mount_dec) {
         this.$buefy.toast.open({
-          message: 'Please specify a declination to point the telescope',
-          type: 'is-danger'
-        })
+          message: "Please specify a declination to point the telescope",
+          type: "is-danger",
+        });
       }
 
       // If the coordinates are specified, send the command
       if (this.mount_dec && this.mount_ra) {
-        const move_telescope_command_params = this.mount_slew_radec_command.form
-        const camera_expose_command_params = this.camera_expose_command.form
+        const move_telescope_command_params = this.mount_slew_radec_command.form;
+        const camera_expose_command_params = this.camera_expose_command.form;
 
         // First send the goto command, then send the expose command.
-        // Order of the commands is important. 
-        this.send_site_command(move_telescope_command_params).then((response) => {
-          this.send_site_command(camera_expose_command_params)
-        })
+        // Order of the commands is important.
+        this.send_site_command(move_telescope_command_params).then(
+          (response) => {
+            this.send_site_command(camera_expose_command_params);
+          }
+        );
       }
+    },
 
-
-
-    }
+    handle_coordinate_search_results(search_results) {
+      if (!search_results.error) {
+        this.mount_ra = search_results.ra.toFixed(4);
+        this.mount_dec = search_results.dec.toFixed(4);
+        // make sure to change this after the coordinates, since the object name is cleared 
+        // after large changes in the coordinate positions. Details in vuex command_params.
+        this.mount_object = search_results.searched_name;
+      } else {
+        this.mount_ra = "";
+        this.mount_dec = "";
+        this.$buefy.toast.open({
+          message: `Could not resolve object with name ${search_results.searched_name}`,
+          type: "is-warning",
+          duration: 4000,
+        });
+      }
+    },
   },
 
   computed: {
     sitecode() {
-      return this.$route.params.sitecode
+      return this.$route.params.sitecode;
     },
 
-    ...mapGetters('sitestatus', [
-      'site_is_online',
-      'mount_state',
-      'telescope_state',
-      'buildTelescopeTabStatus1Shorter',
-      'buildTelescopeTabStatus2',
-      'telescope_message',
-      'mount_message',
+    ...mapGetters("sitestatus", [
+      "site_is_online",
+      "mount_state",
+      "telescope_state",
+      "buildTelescopeTabStatus1Shorter",
+      "buildTelescopeTabStatus2",
+      "telescope_message",
+      "mount_message",
     ]),
 
     mount_ra: {
-      get() { return this.$store.getters['command_params/mount_ra']},
-      set(val) { this.$store.commit('command_params/mount_ra', val)},
+      get() {
+        return this.$store.getters["command_params/mount_ra"];
+      },
+      set(val) {
+        this.$store.commit("command_params/mount_ra", val);
+      },
     },
     mount_dec: {
-      get() { return this.$store.getters['command_params/mount_dec']},
-      set(val) { this.$store.commit('command_params/mount_dec', val)},
+      get() {
+        return this.$store.getters["command_params/mount_dec"];
+      },
+      set(val) {
+        this.$store.commit("command_params/mount_dec", val);
+      },
     },
     mount_object: {
-      get() { return this.$store.getters['command_params/mount_object']},
-      set(val) { this.$store.commit('command_params/mount_object', val)},
+      get() {
+        return this.$store.getters["command_params/mount_object"];
+      },
+      set(val) {
+        this.$store.commit("command_params/mount_object", val);
+      },
     },
 
     telescope_selection: {
-      get() { return this.$store.getters['command_params/telescope_selection']},
-      set(val) { this.$store.commit('command_params/telescope_selection', val)},
+      get() {
+        return this.$store.getters["command_params/telescope_selection"];
+      },
+      set(val) {
+        this.$store.commit("command_params/telescope_selection", val);
+      },
     },
 
     telescope_coordinate_frame: {
-      get() { return this.$store.getters['command_params/telescope_coordinate_frame']},
-      set(val) { this.$store.commit('command_params/telescope_coordinate_frame', val)},
+      get() {
+        return this.$store.getters["command_params/telescope_coordinate_frame"];
+      },
+      set(val) {
+        this.$store.commit("command_params/telescope_coordinate_frame", val);
+      },
     },
   },
-
-}
+};
 </script>
 
 <style scoped lang="scss">

--- a/src/components/NavbarSiteDropdown.vue
+++ b/src/components/NavbarSiteDropdown.vue
@@ -172,7 +172,15 @@ export default {
 @import "@/style/_responsive.scss";
 
 ::v-deep .navbar-dropdown {
-    left: -200px;
+  @include tablet {
+    left: -500px;
+  }
+  @include widescreen {
+    left: -300px;
+  }
+  @include fullhd {
+    left: -100px;
+  }
 }
 .dropdown-wrapper {
     display: flex;

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -66,21 +66,10 @@
 
         set_lengths() {
             let choices = document.getElementsByClassName(this.instance_class)
-            //let choices = document.getElementsByClassName('testitem')
-            //let choices = this.$refs.tab_labels
             let max_width = 50;
-            console.log( 'labels: ', choices)
-            console.log('length: ', choices.length)
-            //console.log(this.$refs.tabs_container)
-            //for (let i = 0; i < choices.length; ++i) {
-                //choices[i].style.width = "max-content"
-            //}
             for (let i = 0; i < choices.length; ++i) {
                 max_width = Math.max(max_width, choices[i].offsetWidth)
-                console.log(choices[i].offsetWidth)
-                console.log(max_width)
             }
-            console.log(max_width)
             return max_width
         }
     },
@@ -93,20 +82,10 @@
         max_tab_width() {
             
             let choices = document.getElementsByClassName(this.instance_class)
-            //let choices = document.getElementsByClassName('testitem')
-            //let choices = this.$refs.tab_labels
             let max_width = 50;
-            console.log( 'labels: ', choices)
-            //console.log(this.$refs.tabs_container)
-            //for (let i = 0; i < choices.length; ++i) {
-                //choices[i].style.width = "max-content"
-            //}
             for (let i = 0; i < choices.length; ++i) {
                 max_width = Math.max(max_width, choices[i].offsetWidth)
-                console.log(choices[i].offsetWidth)
-                console.log(max_width)
             }
-            console.log(max_width)
             return max_width
         },
 

--- a/src/mixins/target_names.js
+++ b/src/mixins/target_names.js
@@ -1,0 +1,36 @@
+import axios from 'axios'
+export const target_names = {
+
+  computed: {
+
+  },
+
+  methods: {
+
+
+        get_coordinates_from_object_name(common_name) {
+            let url = "https://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame.jsonp?object=" + encodeURIComponent(common_name);
+
+            let ra, dec, name
+            let error = false
+            return new Promise(resolve => {
+                axios.get(url).then( response => {
+                    let result = JSON.parse(response.data.slice(10,-3))
+                        if (!result.Target.Resolver || !result.Target.Resolver.jradeg || !result.Target.Resolver.jdedeg) {
+                            console.error('failed to fetch coordinates for ', common_name)
+                            error = true
+                        } else {
+                            ra = result.Target.Resolver.jradeg / 15  // degrees to decimal hours
+                            dec = result.Target.Resolver.jdedeg 
+                            name = result.Target.Resolver.oname
+                        }
+                        let results = { ra, dec, name, error }
+                        resolve(results)
+                    })
+                })
+        },
+
+
+  }
+
+}

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -3,6 +3,7 @@
  *  for commands (eg. exposure time).
  *  
  */
+import helpers from '../../utils/helpers'
 
 const state = {
 
@@ -86,8 +87,36 @@ const getters = {
 
 const mutations = {
 
-    mount_ra(state, val) { state.mount_ra = val; },
-    mount_dec(state, val) { state.mount_dec = val; },
+    mount_ra(state, val) { 
+        // Clear the mount object name if the new coordinates have changed significantly
+        const large_anglular_difference_degrees = 3
+
+        let old_ra = helpers.hour2degree(state.mount_ra) // convert hours to degrees
+        let new_ra = helpers.hour2degree(val)
+        let dec = state.mount_dec // since dec doesn't change here, use it for both positions
+        let angle = helpers.angular_distance(old_ra, dec, new_ra, dec)
+        if (angle !== NaN & angle > large_anglular_difference_degrees) {
+            state.mount_object = ''
+        }
+
+        // finally, update the right ascension 
+        state.mount_ra = val; 
+    },
+    mount_dec(state, val) { 
+        // Clear the mount object name if the new coordinates have changed significantly
+        const large_anglular_difference_degrees = 3
+
+        let old_dec = state.mount_dec
+        let new_dec = val
+        let ra = state.mount_ra // since ra doesn't change here, use it for the both positions
+        let angle = helpers.angular_distance(ra, old_dec, ra, new_dec)
+        if (angle !== NaN & angle > large_anglular_difference_degrees) {
+            state.mount_object = ''
+        }
+
+        // finally, update the declination
+        state.mount_dec = val; 
+    },
     mount_object(state, val) { state.mount_object = val; },
 
     telescope_selection(state, val) { state.telescope_selection = val; },

--- a/src/store/modules/drawshapes.js
+++ b/src/store/modules/drawshapes.js
@@ -123,21 +123,24 @@ const mutations = {
         state[shape].splice(index, 1)
     },
 
+    removeAllShapesOfType(state, type) {
+        state[type].splice(0)
+    },
+
     crosshairsVisible( state, isVisibleBool) {
       state.crosshairsVisible = isVisibleBool
     },
 }
 
 const actions = {
-    deleteAllShapes({state, commit}) {
-      commit('selectedId', 'none')
-      commit('activeDrawShape', 'none')
-      // Remove each shape one at a time to work nicely with the svg rendering updates.
-      // There may be a cleaner solution but this is fast enough for any reasonable number of shapes. 
-      state.points.forEach(p => commit('removeElement', {shape: 'point', id: p.id}))
-      state.lines.forEach(p => commit('removeElement', {shape: 'lines', id: p.id}))
-      state.circles.forEach(p => commit('removeElement', {shape: 'circles', id: p.id}))
-      state.rects.forEach(p => commit('removeElement', {shape: 'rects', id: p.id}))
+    deleteAllShapes({state, getters, commit}) {
+        // deselect the selected shape so we don't have a selection pointing to nothing
+        commit('selectedId', 'none')
+        commit('activeDrawShape', 'none')
+
+        // remove the shape objects from their respective arrays
+        let shape_types = ['points', 'lines', 'rects', 'circles']
+        shape_types.forEach( shape_type => commit('removeAllShapesOfType', shape_type))
     },
     deleteShape({state, commit}, id) {
         const shape = idToShapelistName(id)

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -168,6 +168,12 @@ var helpers = {
     degree2hour: deg => {
         return deg > 0 ? deg / 15 : (deg + 360) / 15
     },
+    rad2deg: rad => { 
+        return rad * 360 / (2 * Math.PI) 
+    },
+    deg2rad: deg => { 
+        return deg * (2 * Math.PI) / 360 
+    },
     clamp: (val, min, max) => {
         return Math.max(Math.min(val, max), min)
     },
@@ -178,6 +184,37 @@ var helpers = {
         y1 = a[1];
         y2 = b[1];
         return Math.sqrt(Math.pow((x2-x1), 2) + Math.pow((y2-y1), 2));
+    },
+
+    /**
+     * Return the angular separation, in degrees, between two coordinates. 
+     * RA and Dec are inputs in decimal degrees because that is the most common unit we use for coordinates.
+     * 
+     * Formula obtained from https://www.gyes.eu/calculator/calculator_page1.htm
+     * @param {Number} ra1  RA of object 1, in decimal degrees
+     * @param {Number} dec1 Dec of object 1, in decimal degrees 
+     * @param {Number} ra2  RA of obejct 2, in decimal degrees 
+     * @param {Number} dec2 Dec of object 2, in decimal degrees 
+     */
+    angular_distance(ra1, dec1, ra2, dec2) {
+        // convert to radians to use with js trig functions
+        let ra1_r   = this.deg2rad(ra1)
+        let dec1_r  = this.deg2rad(dec1)
+        let ra2_r   = this.deg2rad(ra2)
+        let dec2_r  = this.deg2rad(dec2)
+        
+        // Equation for angular distance A:
+        // cos(A) = X + Y
+        // where    X = sin(dec1)sin(dec2) 
+        // and      Y = cos(dec1)cos(dec2)cos(ra1 - ra2) 
+        
+        let X = Math.sin(dec1_r) * Math.sin(dec2_r)
+        let Y = Math.cos(dec1_r) * Math.cos(dec2_r) * Math.cos(ra1_r - ra2_r)
+
+        let A = Math.acos( X + Y )
+
+        // convert A to degrees before returning
+        return this.rad2deg(A)
     },
 }
 

--- a/src/views/info/About.vue
+++ b/src/views/info/About.vue
@@ -1,22 +1,29 @@
 <template>
-  <div class="about container">
+  <div class="about">
     <SiteNavbar />
-    <slot>
-      <div class="description-text">
-        <h1 class="title">Photon Ranch</h1>
-        <p>
-          PTR@LCO is a new education project designed to extend the education
-          programs at Las Cumbres Observatory by offering a self-paced
-          laboratory based course entitled "Astronomy and the Scientific Method"
-          aimed at grade levels 5-8 but accessible by learners of all ages. The
-          course is supported by a brand-new telescope network of similar scale
-          to the Las Cumbres Observatory with a focus on remote and scheduled
-          usage, in contrast to purely robotic usage, with a more heterogenous
-          range of telescopes (from 200mm to 24”) and detectors (CMOS and
-          spectrographs), in contrast to the homogenous instrumentation of LCO.
-        </p>
-      </div>
-    </slot>
+    <div class="container">
+      <slot>
+        <div class="description-text">
+          <h1 class="title">Photon Ranch</h1>
+          <p>
+            PTR@LCO is a new education project designed to extend the education
+            programs at Las Cumbres Observatory by offering a self-paced
+            laboratory based course entitled "Astronomy and the Scientific
+            Method" aimed at grade levels 5-8 but accessible by learners of all
+            ages.
+          </p>
+          <br>
+          <p>
+            The course is supported by a brand-new telescope network of similar
+            scale to the Las Cumbres Observatory with a focus on remote and
+            scheduled usage, in contrast to purely robotic usage, with a more
+            heterogenous range of telescopes (from 200mm to 24”) and detectors
+            (CMOS and spectrographs), in contrast to the homogenous
+            instrumentation of LCO.
+          </p>
+        </div>
+      </slot>
+    </div>
   </div>
 </template>
 
@@ -32,6 +39,7 @@ export default {
 <style lang="scss" scoped>
 .about {
   min-height: 100vh;
+  width: 100vw;
 }
 .description-text {
   margin: 2em;

--- a/src/views/info/Resources.vue
+++ b/src/views/info/Resources.vue
@@ -1,15 +1,18 @@
 
 <template>
-  <div class="Resources container">
+  <div class="resources">
     <SiteNavbar />
-    <slot>
-      <div class="description-text">
-        <h1 class="title">Observing Resources</h1>
-        <p>
-          This page will provide information about astronomy and the process of observing. 
-        </p>
-      </div>
-    </slot>
+    <div class="container">
+      <slot>
+        <div class="description-text">
+          <h1 class="title">Observing Resources</h1>
+          <p>
+            This page will provide information about astronomy and the process
+            of observing.
+          </p>
+        </div>
+      </slot>
+    </div>
   </div>
 </template>
 
@@ -25,6 +28,7 @@ export default {
 <style lang="scss" scoped>
 .resources {
   min-height: 100vh;
+  width: 100vw;
 }
 .description-text {
   margin: 2em;


### PR DESCRIPTION
A few miscellaneous changes here:
- fixed page size bug that caused the observatories menu to render in a small vertically scrolling slot (thanks for finding this Darren)
- fixed the x-positioning of the observatories menu given the additional menu items to the left
- built a form component for searching sky objects by name. Added this to the telescopes command tab and targets page. 
- added some logic for clearing the object name if coordinates change by more than a few degrees. This is so if I search for m42 and then adjust the pointing slightly, I don't lose the m42 object name in the command. But if I search for m42 and then go to a very different place in the sky, m42 won't accidentally get sent with commands.
- fix a bug where clearing all the drawn shapes on the image (lines, etc.) wouldn't clear everything
- remove some console.log statements 