### PR TITLE
Redirect back to previous page after logout

### DIFF
--- a/src/mixins/user_mixin.js
+++ b/src/mixins/user_mixin.js
@@ -48,11 +48,11 @@ export const user_mixin = {
     },
 
     logout() {
-      // make sure the logout happens before redirect.
-      // otherwise, the redirect check for authentication might log the user back in.
+      // save the path we will redirect back to after logout is complete
+      window.localStorage.setItem('ptr_logout_redirect_path', this.$router.currentRoute.fullPath)
       this.$auth.logout({
-        returnTo: window.location.origin
-      }).then($router.go)
+        returnTo: `${window.location.origin}/logout`
+      })
     },
 
 

--- a/src/router.js
+++ b/src/router.js
@@ -4,6 +4,8 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import store from './store'
 
+import { user_mixin } from './mixins/user_mixin'
+
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
 import AdminOnly from './views/AdminOnly.vue'
@@ -92,6 +94,16 @@ const router = new VueRouter({
       },
     },
     { path: '/notfound', name: 'notfound', component: NotFound },
+
+    {
+      path: '/logout',
+      name: 'logout',
+      beforeEnter(to, from, next) {
+        // Get the route where the user clicked 'logout'. We want to redirect back to this page. 
+        let redirect_route = window.localStorage.getItem('ptr_logout_redirect_path') || '/'
+        return next(redirect_route)
+      }
+    },
 
     // handle page not found
     { path: '*', redirect: '/notfound' },

--- a/src/views/ControlRoom.vue
+++ b/src/views/ControlRoom.vue
@@ -1,12 +1,11 @@
 <template>
 <div class="page-wrapper" >
-
+    <Chatlio />
     <!-- top navbar -->
     <b-navbar class="navbar is-dark">
         <template slot="start">
             <b-navbar-item class="nav-item">{{sitecode}}</b-navbar-item>
-        </template>
-        <template slot="end">
+            <b-navbar-item><div style="border-right: 1px solid grey; margin-left: 1em; height: 100%;"/></b-navbar-item>
             <b-navbar-item tag="div">
                 <div v-if="$auth.isAuthenticated" class="navbar-item has-dropdown is-hoverable is-dark">
                     <div class="navbar-link">
@@ -29,41 +28,29 @@
     <!-- main page content: columns -->
     <div class="cr-columns">
         <div class="command-tabs" style="display:flex; flex-direction: column;">
-            <!--div style="flex-shrink: 0; height: 100%; width: 25px; border: 1px solid red;"><</div-->
-            <!--CommandTabsAccordion :initInstrumentOpenView="5" /-->
-            <Chatlio />
             <CommandTabsWide style="width: 100%;" :initInstrumentOpenView="5" />
             <div style="height: 5em; flex-shrink: 0;" />
         </div>
         <div class="image-view">
-
-            <!--Tabs class="control-room-main-tabs"-->
-                <!--TabItem title="images"-->
-                <div>
-                    <ControlRoomImages :sitecode="sitecode" />
-                    <div class="analysis-tabs-wrapper">
-                    <Tabs class="analysis-tools-tabs">
-                        <TabItem title="statistics">
-                            <ImageStatisticsViewer />
-                        </TabItem>
-                        <TabItem title="histogram">
-                            <HistogramTool />
-                        </TabItem>
-                        <TabItem title="line profile">
-                            <LineProfileInspection />
-                        </TabItem>
-                        <TabItem title="image info">
-                            <ImageMetadataViewer />
-                        </TabItem>
-                    </Tabs>
-                    </div>
+            <div>
+                <ControlRoomImages :sitecode="sitecode" />
+                <div class="analysis-tabs-wrapper">
+                <Tabs class="analysis-tools-tabs">
+                    <TabItem title="statistics">
+                        <ImageStatisticsViewer />
+                    </TabItem>
+                    <TabItem title="histogram">
+                        <HistogramTool />
+                    </TabItem>
+                    <TabItem title="line profile">
+                        <LineProfileInspection />
+                    </TabItem>
+                    <TabItem title="image info">
+                        <ImageMetadataViewer />
+                    </TabItem>
+                </Tabs>
                 </div>
-                <!--/TabItem-->
-                <!--TabItem title="sky chart"-->
-                    <!--SiteTargets :sitecode="sitecode" /-->
-                <!--/TabItem-->
-            <!--/Tabs-->
-
+            </div>
         </div>
         <div class="skychart-section">
             <div class="ptr-aladin-parent-div">
@@ -71,14 +58,6 @@
             </div>
             <TheSkyChart class="skychart-component" />
         </div>
-        <!--div class="telescope-info">
-            <TelescopeLivestream class="telescope-livestream" />
-            <div class="status-summary">
-                <div>Telescope: Parked</div>
-                <div>Roof: closed</div>
-                <div>weather: ok</div>
-            </div>
-        </div-->
     </div>
 
     <!-- Status at bottom of page -->

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -1,44 +1,49 @@
 <template>
-  <div class="container">
-    <div style="height: 25px;"/>
-    <div class="top-section">
-      <div class="img-container" style="width: 200px;">
+  <div>
+    <SiteNavbar />
+    <div class="container">
+      <div style="height: 25px" />
+      <div class="top-section">
+        <div class="img-container" style="width: 200px">
           <b-image
             :src="$auth.user.picture"
             alt="alt text"
             ratio="1by1"
             :rounded="true"
-            :lazy="false" ></b-image>
-          </div>
+            :lazy="false"
+          ></b-image>
+        </div>
         <p class="title profile-name">{{ $auth.user.name }}</p>
       </div>
       <!--p>{{ $auth.user.email }}</p-->
-    <div>
-      <pre>{{ JSON.stringify($auth.user, null, 2) }}</pre>
-      <p>break</p>
-      <button @click="showAuth">auth</button>
-      <button @click="tokenWithPopup">getTokenWithPopup</button>
-      <button @click="tokenSilently">getTokenSilently</button>
+      <div>
+        <pre>{{ JSON.stringify($auth.user, null, 2) }}</pre>
+        <p>break</p>
+        <button @click="showAuth">auth</button>
+        <button @click="tokenWithPopup">getTokenWithPopup</button>
+        <button @click="tokenSilently">getTokenSilently</button>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+import SiteNavbar from "@/components/SiteNavbar";
 export default {
   name: "Profile",
+  components: { SiteNavbar },
   methods: {
-
     async tokenWithPopup() {
-      console.log(await this.$auth.getTokenWithPopup())
+      console.log(await this.$auth.getTokenWithPopup());
     },
     async tokenSilently() {
-      return await this.$auth.getTokenSilently()
+      return await this.$auth.getTokenSilently();
     },
     showAuth() {
-      console.log(this.$auth)
+      console.log(this.$auth);
     },
     async getTokenClaims() {
-      return await this.$auth.getIdTokenClaims()
+      return await this.$auth.getIdTokenClaims();
     },
   },
 };


### PR DESCRIPTION
This PR introduces a change to the logout flow: instead of always redirecting back to the home page, users are redirected back to the page they were on. 

The main reason for this change (besides perhaps being more intuitive to users) is that we do not want users to be able to navigate to other pages from the control room. Before this change, users who log out in the control room browser cannot get back to the control room page to log in again, because the browser is set up in kiosk mode (disabling browser navigation). 

Auth0, the service we use for user authentication, does not support arbitrary redirects post-logout. As a workaround, the logout routine first saves the route in localStorage. Then the user is logged out via Auth0, redirecting to the /logout endpoint. Finally, this endpoint gets the saved route out of localStorage and redirects back there. 