### PR TITLE
Add object search, slew button to control room

### DIFF
--- a/src/components/status/SiteStatusFooter.vue
+++ b/src/components/status/SiteStatusFooter.vue
@@ -587,6 +587,7 @@ $log-critical: $ptr-red;
   display: grid;
   grid-template-columns: 220px 1fr;
   width: 90%;
+  line-height: 25px;
 }
 .log-timestamp-group {
   display: flex;


### PR DESCRIPTION
Response to Michael's request here https://lcogt.slack.com/archives/CLAQ9U79B/p1651781718814579

Adds a button to slew the telescope, as well as a field to search for targets by name. 

Not included yet is the ability to search by coordinates in the search box.