### PR TITLE
Project Form rework

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -188,8 +188,8 @@
                                 v-bind:key="filter">
                             {{ filter }}
                         </option>
-                        <option disabled value="------"> ------ </option>
-                        <option v-for="(filter, index) in project_filter_list"
+                        <option disabled v-if="project_sites.length > 0" value="------"> ------ </option>
+                        <option v-if="project_sites.length > 0" v-for="(filter, index) in project_filter_list"
                                 v-bind:value="filter"
                                 v-bind:selected="index === 0"
                                 v-bind:key="filter">

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -552,7 +552,7 @@ export default {
             loaded_project_name: '',
             loaded_project_created_at: '',
 
-            projects_api_url: 'https://projects.photonranch.org/dev',
+            projects_api_url: this.$store.state.dev.projects_endpoint,
             showAdvancedInputs: false,
 
             // Max length for a fits header string value. 
@@ -764,7 +764,6 @@ export default {
         },
 
         saveNewProject() {
-
             this.resetInputWarnings()
             this.verifyForm()
 
@@ -899,7 +898,7 @@ export default {
                 project_name: project_name,
                 created_at: created_at,
             }
-            let project_endpoint = this.$store.dev.state.projects_endpoint + '/get-project'
+            let project_endpoint = this.$store.state.dev.projects_endpoint + '/get-project'
             axios.post(project_endpoint, request_params).then(response => {
                 console.log(response)
             }).catch(err => {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -34,9 +34,8 @@
 
     <div class="project-form">
         <div class="target-row">
-            <b-field 
-                :type="{'is-warning': project_name_changed}"
-                label="Project Name" >
+            <b-field :type="{'is-warning': project_name_changed}"
+                     label="Project Name">
                 <template #message>
                     <div v-if="project_name_changed">Warning: if you change the name of an</div>
                     <div v-if="project_name_changed">existing project, you will have to </div>
@@ -45,77 +44,112 @@
                 <b-input class="project-input" :lazy="false" v-model="project_name"></b-input>
             </b-field>
 
-            <b-field 
-                label="Project Note" 
-                style="max-width: 345px;">
-                <b-input 
-                    :maxlength="max_fits_header_length"
-                    v-model="project_note" ></b-input>
+            <b-field label="Project Note"
+                     style="max-width: 345px;">
+                <b-input :maxlength="max_fits_header_length"
+                         v-model="project_note"></b-input>
             </b-field>
             <b-field style="margin-left: 2em;">
-            <template #label>
-               Active
-                <b-tooltip type="is-dark" label="Projects that are not active can be saved but will not be scheduled to run automatically.">
-                    <b-icon size="is-small" icon="help-circle-outline"></b-icon>
-                </b-tooltip>
-            </template>
-            <b-checkbox v-model="project_constraints.project_is_active"></b-checkbox>
-        </b-field>
+                <template #label>
+                    Active
+                    <b-tooltip type="is-dark" label="Projects that are not active can be saved but will not be scheduled to run automatically.">
+                        <b-icon size="is-small" icon="help-circle-outline"></b-icon>
+                    </b-tooltip>
+                </template>
+                <b-checkbox v-model="project_constraints.project_is_active"></b-checkbox>
+            </b-field>
 
         </div>
 
         <div v-for="n in targets_index" v-bind:key="n" class="target-row">
-            
+
             <!-- we decided to only allow one target per project -->
             <!--b-field :label="' '">
-                <b-checkbox v-model="targets[n-1].active"></b-checkbox>
+                 <b-checkbox v-model="targets[n-1].active"></b-checkbox>
             </b-field-->
 
             <b-field :label="n==1 ? 'Name' : ''" style="width: 130px;">
                 <b-field>
-                    <b-input 
-                        :disabled="!targets[n-1].active"
-                        style="max-width: 150px;"
-                        class="project-input" 
-                        v-model="targets[n-1].name"></b-input>
+                    <b-input :disabled="!targets[n-1].active"
+                             style="max-width: 150px;"
+                             class="project-input"
+                             v-model="targets[n-1].name"></b-input>
                     <p class="control">
                         <b-button class="button" :loading="object_name_search_in_progress" @click="getCoordinatesFromName(n-1)">
-                            <b-icon icon="magnify"/>
+                            <b-icon icon="magnify" />
                         </b-button>
                     </p>
                 </b-field>
             </b-field>
 
-            <b-field 
-                :type="{'is-danger': warn.ra}"
-                :label="n==1 ? 'RA' : ''"
-                style="width: 100px;"
-                >
-                <b-input 
-                    :disabled="!targets[n-1].active" 
-                    v-model="targets[n-1].ra"/>
+            <b-field :type="{'is-danger': warn.ra}"
+                     :label="n==1 ? 'RA' : ''"
+                     style="width: 100px;">
+                <b-input :disabled="!targets[n-1].active"
+                         v-model="targets[n-1].ra" />
             </b-field>
 
-            <b-field 
-                :type="{'is-danger': warn.dec}"
-                :label="n==1 ? 'Dec' : ''"
-                style="width: 100px;"
-                >
-                <b-input 
-                    :disabled="!targets[n-1].active" 
-                    v-model="targets[n-1].dec"/>
+            <b-field :type="{'is-danger': warn.dec}"
+                     :label="n==1 ? 'Dec' : ''"
+                     style="width: 100px;">
+                <b-input :disabled="!targets[n-1].active"
+                         v-model="targets[n-1].dec" />
             </b-field>
-
-
-            <div></div>
 
         </div>
 
+        <!-- Multi-select dropdown, choose which sites a project can be scheduled at -->
+        <!-- Default selection is current site. Currently, there is no "generic site" option -->
+        <div class="site-select">
+            <b-field style="margin-top: 1em;">
+                <template #label>
+                    Sites
+                    <b-tooltip type="is-dark" position="is-right"
+                               label="Choose which observatories this project can be scheduled at.">
+                        <b-icon size="is-small" icon="help-circle-outline"></b-icon>
+                    </b-tooltip>
+                </template>
+
+                <div>
+                    <b-dropdown class="site-dropdown" v-model="project_sites" multiple scrollable>
+                        <template #trigger> 
+                            <b-button class="button" icon-right="menu-down">
+                                Select sites ({{ project_sites.length }})
+                            </b-button>
+                        </template>
+                        <b-dropdown-item class="item" v-for="site in available_sites_real"
+                                         v-bind:value="site"
+                                         v-bind:key="site">
+                            {{ site }}
+                        </b-dropdown-item>
+
+                        <div class="separator">
+                            <div class="line"></div>
+                            <p>SIMULATED</p>
+                            <div class="line"></div>
+                        </div>
+
+                        <b-dropdown-item class="item" v-for="site in available_sites_simulated"
+                                         v-bind:value="site"
+                                         v-bind:key="site">
+                            {{ site }}
+                        </b-dropdown-item>
+                    </b-dropdown>
+                </div>       
+            </b-field>
+            <span v-if="project_sites.length === 0">default ({{ sitecode }})</span>
+            <span v-if="project_sites.indexOf(site) === 0" v-for="site in project_sites">
+                  {{ site }}
+            </span> 
+            <span v-else> , {{ site }} </span>
+        </div>
+
+    
         <!-- we decided to only allow one target per project -->
         <!--button class="button" @click="newTargetRow">add another target</button-->
         <hr>
 
-        <div class="exposure-rows">
+        <div class="exposure-rows" style="margin-top: 1em;">
 
 
             <div v-for="n in exposures_index" v-bind:key="n" class="exposure-row">
@@ -135,28 +169,31 @@
                     </b-select>
                 </b-field>
                 <b-field :label="n==1 ? 'Count' : ''" style="width: 100px;">
-                    <b-input 
-                        size="is-small"
-                        :disabled="!exposures[n-1].active" 
-                        min="1" 
-                        v-model="exposures[n-1].count"/>
+                    <b-input size="is-small"
+                             :disabled="!exposures[n-1].active"
+                             min="1"
+                             v-model="exposures[n-1].count" />
                 </b-field>
                 <b-field :label="n==1 ? 'Exposure [s]' : ''" style="max-width: 100px;">
-                    <b-input 
-                        size="is-small"
-                        :disabled="!exposures[n-1].active" 
-                        min="0" 
-                        v-model="exposures[n-1].exposure"/>
+                    <b-input size="is-small"
+                             :disabled="!exposures[n-1].active"
+                             min="0"
+                             v-model="exposures[n-1].exposure" />
                 </b-field>
                 <b-field :label="n==1 ? 'Filter' : ''">
                     <b-select size="is-small" :disabled="!exposures[n-1].active" v-model="exposures[n-1].filter">
-                        <option
-                            v-for="(filter, index) in project_filter_list"
-                            v-bind:value="filter"
-                            v-bind:selected="index === 0"
-                            v-bind:key="index"
-                            >
-                            {{filter}}
+                        <option v-for="(filter, index) in generic_filter_list"
+                                v-bind:value="filter"
+                                v-bind:selected="index === 0"
+                                v-bind:key="filter">
+                            {{ filter }}
+                        </option>
+                        <option disabled value="------"> ------ </option>
+                        <option v-for="(filter, index) in project_filter_list"
+                                v-bind:value="filter"
+                                v-bind:selected="index === 0"
+                                v-bind:key="filter">
+                            {{ filter }}
                         </option>
                     </b-select>
                 </b-field>
@@ -186,7 +223,7 @@
                     </b-select>
                 </b-field>
                 <b-field :label="n==1 ? 'Dither' : ''">
-                    <b-select size="is-small":disabled="!exposures[n-1].active" v-model="exposures[n-1].dither">
+                    <b-select size="is-small" :disabled="!exposures[n-1].active" v-model="exposures[n-1].dither">
                         <option value="yes"> yes </option>
                         <option value="no"> no </option>
                         <option v-for="i in 25" :key="i-1" :value="i-1"> {{i-1}}</option>
@@ -211,7 +248,7 @@
 
                 <div></div>
             </div>
-            <div/>
+            <div />
         </div>
 
         <button style="margin-top: 1em;" class="button" @click="newExposureRow">
@@ -221,71 +258,61 @@
 
 
         <div>
-            <div
-                class="toggle-advanced-settings"
-                @click="showAdvancedInputs = !showAdvancedInputs"
-                >
+            <div class="toggle-advanced-settings"
+                 @click="showAdvancedInputs = !showAdvancedInputs">
                 {{showAdvancedInputs ? "hide" : "show"}} advanced
             </div>
 
             <br>
 
-            <b-field 
-                v-if="showAdvancedInputs"
-                label="Meridian Flip">
-                <b-field
-                >
+            <b-field v-if="showAdvancedInputs"
+                     label="Meridian Flip">
+                <b-field>
                     <b-radio-button v-model="project_constraints.meridian_flip"
-                        type="is-light"
-                        native-value="east_only">
+                                    type="is-light"
+                                    native-value="east_only">
                         <b-icon icon="close"></b-icon>
                         <span>East Only</span>
                     </b-radio-button>
 
                     <b-radio-button v-model="project_constraints.meridian_flip"
-                        type="is-light"
-                        native-value="west_only">
+                                    type="is-light"
+                                    native-value="west_only">
                         <b-icon icon="check"></b-icon>
                         <span>West Only</span>
                     </b-radio-button>
 
                     <b-radio-button v-model="project_constraints.meridian_flip"
-                        type="is-light"
-                        native-value="flip_ok">
+                                    type="is-light"
+                                    native-value="flip_ok">
                         Flip OK
                     </b-radio-button>
 
                     <b-radio-button v-model="project_constraints.meridian_flip"
-                        type="is-light"
-                        native-value="no_flip">
+                                    type="is-light"
+                                    native-value="no_flip">
                         No Flip
                     </b-radio-button>
                 </b-field>
             </b-field>
-            
+
             <b-field grouped v-if="showAdvancedInputs">
-                <b-field 
-                    v-if="showAdvancedInputs"
-                    label="Ra offset" 
-                    >
-                    <b-input 
-                        style="max-width: 100px"
-                        class="project-input" 
-                        v-model="project_constraints.ra_offset"></b-input>
+                <b-field v-if="showAdvancedInputs"
+                         label="Ra offset">
+                    <b-input style="max-width: 100px"
+                             class="project-input"
+                             v-model="project_constraints.ra_offset"></b-input>
                     <b-select v-model="project_constraints.ra_offset_units">
                         <option value="deg">deg</option>
                         <option value="min">minutes</option>
                         <option value="asec">arcsec</option>
                     </b-select>
                 </b-field>
-                <b-field 
-                    v-if="showAdvancedInputs"
-                    label="Dec offset" 
-                    >
-                    <b-input 
-                        style="max-width: 100px"
-                        class="project-input" 
-                        v-model="project_constraints.dec_offset"></b-input>
+                <b-field v-if="showAdvancedInputs"
+                         label="Dec offset">
+                    <b-input style="max-width: 100px"
+                             class="project-input"
+                             v-model="project_constraints.dec_offset"></b-input>
                     <b-select v-model="project_constraints.dec_offset_units">
                         <option value="deg">deg</option>
                         <option value="asec">arcsec</option>
@@ -293,71 +320,59 @@
                 </b-field>
             </b-field>
 
-            <b-field 
-                v-if="showAdvancedInputs"
-                label="Position Angle" 
-                :type="{'is-danger': warn.position_angle}"
-                >
-                <b-input class="project-input" type="number" min="-360" max="360" v-model="project_constraints.position_angle"/>
+            <b-field v-if="showAdvancedInputs"
+                     label="Position Angle"
+                     :type="{'is-danger': warn.position_angle}">
+                <b-input class="project-input" type="number" min="-360" max="360" v-model="project_constraints.position_angle" />
                 <b-select value="deg">
                     <option value="deg">deg</option>
                 </b-select>
             </b-field>
 
 
-            <b-field 
-                v-if="showAdvancedInputs"
-                label="Max HA (decimal hours, absolute value)" 
-                :type="{'is-danger': warn.max_ha}" >
-                <b-numberinput 
-                    step="0.5" 
-                    type="is-button"
-                    max="12" 
-                    controls-position="compact" 
-                    class="project-input" 
-                    v-model="project_constraints.max_ha"></b-numberinput>
+            <b-field v-if="showAdvancedInputs"
+                     label="Max HA (decimal hours, absolute value)"
+                     :type="{'is-danger': warn.max_ha}">
+                <b-numberinput step="0.5"
+                               type="is-button"
+                               max="12"
+                               controls-position="compact"
+                               class="project-input"
+                               v-model="project_constraints.max_ha"></b-numberinput>
             </b-field>
 
-            <b-field 
-                v-if="showAdvancedInputs"
-                label="Min distance from zenith (degrees)" 
-                :type="{'is-danger': warn.min_zenith_dist}" >
-                <b-numberinput 
-                    step="0.1" 
-                    type="is-button"
-                    max="7.5" 
-                    controls-position="compact" 
-                    class="project-input" 
-                    v-model="project_constraints.min_zenith_dist"></b-numberinput>
+            <b-field v-if="showAdvancedInputs"
+                     label="Min distance from zenith (degrees)"
+                     :type="{'is-danger': warn.min_zenith_dist}">
+                <b-numberinput step="0.1"
+                               type="is-button"
+                               max="7.5"
+                               controls-position="compact"
+                               class="project-input"
+                               v-model="project_constraints.min_zenith_dist"></b-numberinput>
             </b-field>
 
-            <b-field 
-                style="max-width: 150px;"
-                v-if="showAdvancedInputs"
-                label="Max Airmass" 
-                :type="{'is-danger': warn.max_airmass}"
-                >
+            <b-field style="max-width: 150px;"
+                     v-if="showAdvancedInputs"
+                     label="Max Airmass"
+                     :type="{'is-danger': warn.max_airmass}">
                 <b-input class="project-input" v-model="project_constraints.max_airmass"></b-input>
             </b-field>
 
             <b-field grouped v-if="showAdvancedInputs">
-                <b-field 
-                    v-if="showAdvancedInputs"
-                    label="Min Lunar Dist. [deg]" 
-                    :type="{'is-danger': warn.lunar_dist_min}"
-                    >
+                <b-field v-if="showAdvancedInputs"
+                         label="Min Lunar Dist. [deg]"
+                         :type="{'is-danger': warn.lunar_dist_min}">
                     <b-input class="project-input" v-model="project_constraints.lunar_dist_min"></b-input>
                 </b-field>
-                <b-field 
-                    v-if="showAdvancedInputs"
-                    label="Max Lunar Phase %" 
-                    :type="{'is-danger': warn.lunar_phase_max}"
-                    >
+                <b-field v-if="showAdvancedInputs"
+                         label="Max Lunar Phase %"
+                         :type="{'is-danger': warn.lunar_phase_max}">
                     <b-input class="project-input" v-model="project_constraints.lunar_phase_max"></b-input>
                 </b-field>
             </b-field>
 
-            <div style="height: 5px;"/>
+            <div style="height: 5px;" />
             <b-field v-if="showAdvancedInputs">
                 <b-checkbox v-model="project_constraints.frequent_autofocus">Autofocus: focus more frequently</b-checkbox>
             </b-field>
@@ -379,25 +394,6 @@
             <b-field v-if="showAdvancedInputs">
                 <b-checkbox v-model="project_constraints.dark_sky_setting">Astronomical Dark & Moon Alt < 6</b-checkbox>
             </b-field>
-            
-            <section v-if="showAdvancedInputs" style="max-width: 50%;">
-            <b-field label="Site tags" style="margin-bottom: 0.5em;">
-                <b-taginput
-                    v-model="project_constraints.site_tags"
-                    type="is-light"
-                    open-on-focus
-                    autocomplete
-                    :data="filtered_site_tags"
-                    :allow-new="false"
-                    @typing="getFilteredSiteTags"
-                    ellipsis
-                    icon="label"
-                    placeholder="Add a site"
-                    aria-close-label="Delete this tag">
-                </b-taginput>
-            </b-field>
-            </section>
-
             <b-field v-if="showAdvancedInputs" label="Generic Instrument">
                 <b-select v-model="project_constraints.generic_instrument">
                     <option value="Main Camera">Main Camera</option>
@@ -467,10 +463,12 @@ export default {
             this.modifying_existing_project = is_existing_project
             this.loaded_project_name = project.project_name
             this.loaded_project_created_at = project.created_at
-            this.loaded_site_tags = project.site_tags
 
             this.project_name = project.project_name
             this.project_events = project.scheduled_with_events
+
+            this.project_sites = project.project_sites
+
             this.targets = project.project_targets.map(target => ({...target, active: true}))
             this.targets_index = this.targets.length
             this.project_note = project.project_note
@@ -488,8 +486,9 @@ export default {
             /*************************************************/
             project_name: '',
             project_events: [],
-
             project_note: '',
+
+            project_sites: [this.sitecode],
 
             exposures_index: 1,
             exposures: [
@@ -518,9 +517,8 @@ export default {
             ],
 
             project_constraints: {
-                project_is_active: false,
+                project_is_active: true,
 
-                site_tags: [],
                 generic_instrument: 'Main Camera',
 
                 meridian_flip: 'flip_ok', // can be ['flip_ok', 'no_flip', 'east_only', 'west_only']
@@ -558,8 +556,6 @@ export default {
             loaded_project_name: '',
             loaded_project_created_at: '',
 
-            filtered_site_tags: [], // List of autocomplete matches for site_tags
-
             projects_api_url: 'https://projects.photonranch.org/dev',
             showAdvancedInputs: false,
 
@@ -572,30 +568,10 @@ export default {
                 "Red",
                 "Green",
                 "Blue",
-                "NIR",
-                "O3",
                 "HA",
-                "N2",
+                "O3",
                 "S2",
-                "ME",
-                "air",
-                "w",
-                "clear",
-                "silica",
-                "up",
-                "gp",
-                "rp",
-                "ip",
-                "zs",
-                "zp",
-                "Y",
-                "U",
-                "B",
-                "V",
-                "Rc",
-                "Ic",
             ],
-                
 
             site: this.sitecode,
 
@@ -623,16 +599,6 @@ export default {
 
     },
     methods: {
-
-        // site_tags autocomplete helper
-        getFilteredSiteTags(text) {
-            this.filtered_site_tags = this.available_sites.filter((option) => {
-                return option
-                    .toString()
-                    .toLowerCase()
-                    .indexOf(text.toLowerCase()) >= 0
-            })
-        },
 
         async getAuthRequestHeader() {
             let token, configWithAuth;
@@ -666,7 +632,6 @@ export default {
 
             this.project_name = '' 
             this.project_events = []
-            this.site_tags = []
             this.targets = [
                 {
                     active: true,
@@ -677,6 +642,8 @@ export default {
             ]
             this.targets_index = 1
             this.project_note = ""
+            this.project_sites = [this.sitecode]
+
             this.exposures = [
                 {
                     active: true,
@@ -695,7 +662,6 @@ export default {
             this.project_constraints = {
                 project_is_active: true,
 
-                site_tags: [],
                 generic_instrument: '',
 
                 ra_offset: 0.0,
@@ -774,6 +740,10 @@ export default {
                     message: "Please avoid '#' in the project name",
                     type: "is-danger"
                 })
+            // If user selects no sites, reset selection to current site
+            if (this.project_sites.length === 0) {
+                this.project_sites = [site]
+                }     
             }
         },
 
@@ -781,7 +751,7 @@ export default {
             Object.keys(this.warn).forEach(k => this.warn[k] = false)
         },
 
-        async addProjectToCalendarEvents(project_name,created_at, project_events) {
+        async addProjectToCalendarEvents(project_name, created_at, project_events) {
             let url = this.calendarBaseUrl + '/add-projects-to-events'
             let body = {
                 "project_id": `${project_name}#${created_at}`,
@@ -820,7 +790,10 @@ export default {
                 // List of objects (targets in the project)
                 project_targets: this.targets
                         .filter(t => t.active)
-                        .map(({active, ...stuff_to_keep}) => stuff_to_keep),
+                        .map(({ active, ...stuff_to_keep }) => stuff_to_keep),
+
+                // List of observatory sites selected
+                project_sites: [this.project_sites],
 
                 // List of objects (exposures to complete for each target).
                 exposures: this.exposures
@@ -875,6 +848,9 @@ export default {
                 project_targets: this.targets
                         .filter(t => t.active)
                         .map(({active, ...stuff_to_keep}) => stuff_to_keep),
+
+                // List of observatory sites selected
+                project_sites: [this.project_sites],
 
                 // List of objects (exposures to complete for each target).
                 exposures: this.exposures
@@ -941,17 +917,40 @@ export default {
         getUserEvents() {
             this.$store.dispatch('user_data/fetchUserEvents', this.user.sub)
         },
+       
+
+        // Function to get filters at any site to populate filter dropdown
+        get_default_filter_options(site) {
+            let site_config = this.global_config[site]
+            let default_filter_wheel_name = site_config.defaults.filter_wheel
+            let filter_wheel_options = site_config.filter_wheel[default_filter_wheel_name].settings.filter_data
+            return filter_wheel_options
+        },
     },
+
     computed: {
 
-        // Append any new filters from the site config to the generic filters list.
+        // Filter dropdown choices update based on which sites are selected.
         project_filter_list() {
             let generics = this.generic_filter_list
-            let config_filters = this.filter_wheel_options.map(x => x[0])
-            var combined_filters = generics.concat(
-                    config_filters.filter((item) => generics.indexOf(item) < 0)
-                )
-            return combined_filters
+            let selected_sites = this.project_sites
+
+            if (selected_sites.length != 0) {
+                let fwo = []
+                for (let site of selected_sites) {
+                    let new_site_filters = this.get_default_filter_options(site).map(x => x[0])
+                    fwo = [...fwo, ...new_site_filters]
+                }
+                // Remove duplicates between site filter lists
+                let all_site_filters = [...new Set(fwo)]
+                // Remove duplicates that appear in generic filters
+                all_site_filters = all_site_filters.filter(item => generics.indexOf(item) < 0)
+                return all_site_filters
+
+            // Default filter set is the generic filter list.
+            } else {
+                return generics
+            }
         },
 
         // True if we're modifying a project and the name is changed.
@@ -974,8 +973,13 @@ export default {
 
         ...mapGetters('site_config', [
             'available_sites',
-            'filter_wheel_options'
-        ]), 
+            'available_sites_real',
+            'available_sites_simulated',
+            'filter_wheel_options',
+        ]),
+        ...mapState('site_config', [
+            'global_config',
+        ]),
         ...mapState('user_data', [
             'user_events',
             'user_projects',
@@ -1012,7 +1016,34 @@ export default {
     background-color: $background;
     padding: 1em;
 }
-
+.site-dropdown {
+    background-color: $body-background-color;
+}
+.site-dropdown .button {
+    width: 130px;
+    background-color: $body-background-color;
+}
+.site-dropdown .item {
+    font-size: 12px;
+    background-color: $body-background-color;
+}
+.separator {
+    display: flex;
+    align-items: center;
+    background-color: $body-background-color;
+    opacity: 0.8;
+}
+.separator .line {
+    height: 0.5px;
+    flex: 1;
+    background-color: silver;
+    opacity: 0.8;
+}
+.separator p {
+    padding: 0 1rem;
+    font-size: 9px;
+    color: silver;
+}
 .toggle-advanced-settings {
     width: 100%;
     border-bottom: $grey solid 1px;
@@ -1023,10 +1054,9 @@ export default {
 .toggle-advanced-settings:hover {
     cursor: pointer;
 }
-
 .exposure-rows {
     max-width: 959px;
-    overflow-x:auto;
+    overflow-x: auto;
 }
 @include tablet {
     .exposure-rows {
@@ -1053,7 +1083,7 @@ export default {
 .target-row {
     display: flex;
     flex-direction: row;
-    align-items:bottom;
+    align-items: bottom;
 }
 .target-row > * {
     margin-right: 8px;

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -583,7 +583,7 @@ export default {
                 lunar_phase_max: false,
             },
 
-            calendarBaseUrl: 'https://calendar.photonranch.org/dev',
+            calendarBaseUrl: this.$store.state.dev.calendar_api,
 
         }
     },

--- a/src/store/modules/dev.js
+++ b/src/store/modules/dev.js
@@ -12,8 +12,10 @@ const state = {
     //jobs_api: "https://jobs.photonranch.org/test",
 
     calendar_api: "https://calendar.photonranch.org/dev",
+    //calendar_api: "https://calendar.photonranch.org/test",
 
     projects_endpoint: "https://projects.photonranch.org/dev", // prod endpoint
+    //projects_endpoint: "https://projects.photonranch.org/test",
 
     logs_endpoint: "https://logs.photonranch.org/logs",  // prod
     //logs_endpoint: "https://logs.photonranch.org/dev",  // dev


### PR DESCRIPTION
This pull request introduces a few changes to the Create a Project form.

The multi-select dropdown "Sites" replaces the "Site Tags" field, previously located in the advanced settings. The purpose of this dropdown is to allow users to choose which sites a project can be automatically scheduled at. Both real and simulated/test sites populate this dropdown, with the default selection being the site the user currently is on. A list of user-selected sites renders below the button.

Options in the Filter field will now change based on which sites a user selects, with a list of generic filters always available.

Currently, we have not defined how similar filters map to one another in the case that a project begins at one site and is scheduled to continue at another site without that filter.