### PR TITLE
Rename dev.js, remove hardcoded API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm run serve
 
 ## Configuration
 
-Api endpoint urls used by the frontend are configured in the vuex module in `src/store/modules/dev.js`.
+Api endpoint urls used by the frontend are configured in the vuex module in `src/store/modules/api_endpoints.js`.
 This provides a mechanism for dynamically toggling between different urls.
 
 The backend services defined here and used for the main deployment (and set by default) are:

--- a/src/components/AdminTools/RecentS3UploadsTable.vue
+++ b/src/components/AdminTools/RecentS3UploadsTable.vue
@@ -97,7 +97,7 @@ export default {
     get_recent_uploads() {
       this.table_is_loading = true;
       let url = `${
-        this.$store.state.dev.active_api
+        this.$store.state.api_endpoints.active_api
       }/recentuploads?site=${encodeURIComponent(this.selected_site)}`;
       axios
         .get(url)

--- a/src/components/AnalysisTools/HistogramTool.vue
+++ b/src/components/AnalysisTools/HistogramTool.vue
@@ -54,7 +54,7 @@ export default {
     methods: {
 
         getHistogram(useSubregion=true) {
-        const url = this.$store.state.dev.quickanalysis_endpoint + '/histogram-clipped'
+        const url = this.$store.state.api_endpoints.quickanalysis_endpoint + '/histogram-clipped'
         let body = {
             "full_filename": this.best_available_full_filename,
             "s3_directory": this.current_image.s3_directory || "data",

--- a/src/components/AnalysisTools/HistogramViewer.vue
+++ b/src/components/AnalysisTools/HistogramViewer.vue
@@ -211,7 +211,7 @@ export default {
 
   computed: {
 
-    ...mapState('dev', ['quickanalysis_endpoint']),
+    ...mapState('api_endpoints', ['quickanalysis_endpoint']),
 
     inner_width() {
       return this.chart_width - this.mleft - this.mright

--- a/src/components/AnalysisTools/ImageStatisticsViewer.vue
+++ b/src/components/AnalysisTools/ImageStatisticsViewer.vue
@@ -67,7 +67,7 @@ export default {
     methods: {
 
     getRegionStats(useSubregion=true) {
-      const url = this.$store.state.dev.quickanalysis_endpoint + '/statistics'
+      const url = this.$store.state.api_endpoints.quickanalysis_endpoint + '/statistics'
 
       let body = {
         "site": this.sitecode,

--- a/src/components/AnalysisTools/LineProfileInspection.vue
+++ b/src/components/AnalysisTools/LineProfileInspection.vue
@@ -161,7 +161,7 @@ export default {
       'subframeFromShape',
     ]),
 
-    ...mapState('dev', ['quickanalysis_endpoint']),
+    ...mapState('api_endpoints', ['quickanalysis_endpoint']),
 
     xScale() {
       let margin = this.chartMargin

--- a/src/components/DownloadInterface.vue
+++ b/src/components/DownloadInterface.vue
@@ -65,7 +65,7 @@ export default {
         fits_size: this.fits_size,
         site: this.site,
       };
-      const url = `${this.$store.state.dev.active_api}/downloadzip`
+      const url = `${this.$store.state.api_endpoints.active_api}/downloadzip`
       this.zip_download_waiting = true;
       axios.post(url, request_body).then((response) => {
           let download_url = response.data.message;

--- a/src/components/FormElements/CancelButton.vue
+++ b/src/components/FormElements/CancelButton.vue
@@ -42,7 +42,7 @@ export default {
 
             this.is_loading = true
 
-            const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.site}`
+            const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.site}`
             const options = await this.getAuthHeader()
             axios.post(url, this.cancel_request_body, options).then(response => {
                 this.is_loading = false

--- a/src/components/FormElements/CommandButton.vue
+++ b/src/components/FormElements/CommandButton.vue
@@ -48,7 +48,7 @@ export default {
             this.data.form.mount=this.data.mount
             this.data.form.timestamp = parseInt(Date.now() / 1000)
 
-            const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.data.site}`
+            const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.data.site}`
             const options = await this.getAuthHeader()
             axios.post(url, this.data.form, options).then(response => {
                 this.isLoading = false

--- a/src/components/ImageDisplay/ButtonRowBelowImage.vue
+++ b/src/components/ImageDisplay/ButtonRowBelowImage.vue
@@ -90,7 +90,7 @@ export default {
 
   methods: {
     download_fits_previous_24hrs() {
-      const url = `${this.$store.state.dev.active_api}/downloadzip`
+      const url = `${this.$store.state.api_endpoints.active_api}/downloadzip`
       const args = {
         site: this.$route.params.sitecode,
         fits_size: 'small',
@@ -185,7 +185,7 @@ export default {
 
     async download_tif(size, stretch) {
       this.download_waiting = true
-      const url = `${this.$store.state.dev.active_api}/download`
+      const url = `${this.$store.state.api_endpoints.active_api}/download`
       let body = {}
 
       if (size == "large") {

--- a/src/components/ImageDisplay/FitsHeaderModal.vue
+++ b/src/components/ImageDisplay/FitsHeaderModal.vue
@@ -117,8 +117,7 @@ export default {
                 return
             }
             this.headerIsLoading = true 
-            //let url = `https://api.photonranch.org/api/fitsheader/${this.image.base_filename}/`
-            let url = this.$store.state.dev.active_api + `/fitsheader/${this.image.base_filename}/`
+            let url = this.$store.state.api_endpoints.active_api + `/fitsheader/${this.image.base_filename}/`
             let response = axios.get(url).then(response => {
                 this.fitsHeader = response.data
             }).finally(() => {

--- a/src/components/ImageFilter.vue
+++ b/src/components/ImageFilter.vue
@@ -162,7 +162,7 @@ export default {
       }
 
       this.$store.dispatch('images/toggle_live_data', false)
-      let url = this.$store.state.dev.active_api + '/filtered_images';
+      let url = this.$store.state.api_endpoints.active_api + '/filtered_images';
       let body = { 
           method: "GET",
           params: filterparams,

--- a/src/components/ImagesTable.vue
+++ b/src/components/ImagesTable.vue
@@ -239,7 +239,7 @@ export default {
       let large_fits_reduction_level = this.$store.state.images.large_fits_reduction_level
       let object_name = `${image.base_filename}-${image.data_type}${large_fits_reduction_level}.fits.bz2`
 
-      const url = `${this.$store.state.dev.active_api}/download`
+      const url = `${this.$store.state.api_endpoints.active_api}/download`
       let body = {
         s3_directory: image.s3_directory,
         object_name: object_name,
@@ -260,7 +260,7 @@ export default {
       let large_fits_reduction_level = this.$store.state.images.large_fits_reduction_level
       let object_name = `${image.base_filename}-${image.data_type}${large_fits_reduction_level}.fits.bz2`
 
-      const url = `${this.$store.state.dev.active_api}/download`
+      const url = `${this.$store.state.api_endpoints.active_api}/download`
       let body = {
         s3_directory: image.s3_directory,
         object_name: object_name,

--- a/src/components/LogStream.vue
+++ b/src/components/LogStream.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         
-    <-- enable these buttons for easier manual testing>
+    <!-- enable these buttons for easier manual testing>
     <button @click="send_fake_log_ws" class="button ">send ws log</button>
     <button @click="send_fake_log_http" class="button ">send http log</button>
     <button @click="get_recent_logs" class="button">get recent logs</button>
@@ -238,7 +238,7 @@ export default {
     },
 
     computed: {
-        ...mapState('dev', [
+        ...mapState('api_endpoints', [
             'logs_ws_endpoint',
             'logs_endpoint',
         ])

--- a/src/components/NavbarSiteDropdown.vue
+++ b/src/components/NavbarSiteDropdown.vue
@@ -91,7 +91,7 @@ export default {
       window.open(url);
     },
     update_all_site_images() {
-      const url = this.$store.state.dev.active_api + `/latest_image_all_sites`
+      const url = this.$store.state.api_endpoints.active_api + `/latest_image_all_sites`
       axios.get(url).then(response => {
         this.site_images = response.data
       })

--- a/src/components/ObservatoryRestartCommand.vue
+++ b/src/components/ObservatoryRestartCommand.vue
@@ -81,7 +81,7 @@ export default {
     async send_command() {
       this.is_loading = true;
 
-      const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.site}`;
+      const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.site}`;
       const options = await this.getAuthHeader();
       axios
         .post(url, this.restart_command_body, options)

--- a/src/components/OperatorMessage.vue
+++ b/src/components/OperatorMessage.vue
@@ -76,7 +76,7 @@ export default {
     },
     methods: {
         get_note() {
-            const url = this.$store.state.dev.active_api + '/nightlog/' + this.site
+            const url = this.$store.state.api_endpoints.active_api + '/nightlog/' + this.site
             axios.get(url).then(response => {
                 console.log(response)
                 this.note = response.data
@@ -87,7 +87,7 @@ export default {
             })
         },
         new_note() {
-            const url = this.$store.state.dev.active_api + '/nightlog/' + this.site
+            const url = this.$store.state.api_endpoints.active_api + '/nightlog/' + this.site
             let note_data = {
                 site: this.$route.params.sitecode,
                 username: this.userName,

--- a/src/components/SiteEventsModal.vue
+++ b/src/components/SiteEventsModal.vue
@@ -109,7 +109,7 @@ export default {
                 Object.keys(site_events).forEach(key => site_events[key] += 2415020)  
 
             } else {
-                let url = `https://api.photonranch.org/api/events?site=${this.sitecode}`
+                let url = `${this.$store.state.api_endpoints.active_api}/events?site=${this.sitecode}`
                 site_events = await axios.get(url)
                 site_events = site_events.data
             }

--- a/src/components/SitesOverviewCards.vue
+++ b/src/components/SitesOverviewCards.vue
@@ -65,7 +65,7 @@ export default {
   },
   methods: {
     getSiteOpenStatus() {
-      const url = this.$store.state.dev.status_endpoint + '/allopenstatus'
+      const url = this.$store.state.api_endpoints.status_endpoint + '/allopenstatus'
       axios.get(url).then(resp => {
         this.site_online_status = _.orderBy(resp.data, [s => s.site], ['asc'])
       })
@@ -80,7 +80,7 @@ export default {
       return a
     },
     updateAllSiteImages() {
-      const url = this.$store.state.dev.active_api + `/latest_image_all_sites`
+      const url = this.$store.state.api_endpoints.active_api + `/latest_image_all_sites`
       axios.get(url).then(response => {
         this.site_images = response.data
       })

--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -457,7 +457,7 @@ export default {
 
     // Call the photonranch api to get moon times. 
     async getMoonTimesFromAPI(start, end) {
-      let url = "https://api.photonranch.org/api/events/moon/rise-set-illum";
+      let url = `${this.$store.state.api_endpoints.active_api}/events/moon/rise-set-illum`;
       let payload = {
         params: {
           start: start,
@@ -859,7 +859,7 @@ export default {
       // Make request headers and include token.
       // Requires user to be logged in.
       let header = await this.getConfigWithAuth();
-      let url = `${this.$store.state.dev.calendar_api}/is-user-scheduled`;
+      let url = `${this.$store.state.api_endpoints.calendar_api}/is-user-scheduled`;
       let user_id = this.$auth.user.sub;
       let body = {
         user_id: user_id,
@@ -879,7 +879,7 @@ export default {
       // Requires user to be logged in.
       let config = await this.getConfigWithAuth();
 
-      let url = `${this.$store.state.dev.calendar_api}/newevent`;
+      let url = `${this.$store.state.api_endpoints.calendar_api}/newevent`;
       let eventToPost = {
         event_id: newEvent.id,
         start: moment(newEvent.startStr).utc().format(),
@@ -929,7 +929,7 @@ export default {
      */
     async deleteButtonClicked(eventToDelete) {
       let config = await this.getConfigWithAuth();
-      let url = `${this.$store.state.dev.calendar_api}/delete`;
+      let url = `${this.$store.state.api_endpoints.calendar_api}/delete`;
       let body = {
         event_id: eventToDelete.id,
         start: moment(eventToDelete.startStr).utc().format(),
@@ -959,7 +959,7 @@ export default {
       // Make request headers and include token.
       // Requires user to be logged in.
       let config = await this.getConfigWithAuth();
-      let url = `${this.$store.state.dev.calendar_api}/modifyevent`;
+      let url = `${this.$store.state.api_endpoints.calendar_api}/modifyevent`;
       let theModifiedEvent = {
         event_id: modifiedEvent.id,
         start: moment(modifiedEvent.startStr).utc().format(),
@@ -1012,7 +1012,7 @@ export default {
 
     async fetchSiteEvents(fetchInfo) {
       let site = this.calendarSite;
-      const url = `${this.$store.state.dev.calendar_api}/siteevents`;
+      const url = `${this.$store.state.api_endpoints.calendar_api}/siteevents`;
       const options = {
         headers: {
           "Content-Type": "application/json;charset=UTF-8",

--- a/src/components/calendar/UserEventsTable.vue
+++ b/src/components/calendar/UserEventsTable.vue
@@ -126,10 +126,6 @@ export default {
             siteTime: '-',
             utcTime: '-',
 
-            // URL for the calendar backend api
-            //backendUrl: 'https://m1vw4uqnpd.execute-api.us-east-1.amazonaws.com',
-            backendUrl: 'https://calendar.photonranch.org',
-
             // Events Table Settings
             isEmpty: true,
             isNarrowed: true,

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -552,7 +552,7 @@ export default {
             loaded_project_name: '',
             loaded_project_created_at: '',
 
-            projects_api_url: this.$store.state.dev.projects_endpoint,
+            projects_api_url: this.$store.state.api_endpoints.projects_endpoint,
             showAdvancedInputs: false,
 
             // Max length for a fits header string value. 
@@ -583,7 +583,7 @@ export default {
                 lunar_phase_max: false,
             },
 
-            calendarBaseUrl: this.$store.state.dev.calendar_api,
+            calendarBaseUrl: this.$store.state.api_endpoints.calendar_api,
 
         }
     },
@@ -898,7 +898,7 @@ export default {
                 project_name: project_name,
                 created_at: created_at,
             }
-            let project_endpoint = this.$store.state.dev.projects_endpoint + '/get-project'
+            let project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
             axios.post(project_endpoint, request_params).then(response => {
                 console.log(response)
             }).catch(err => {

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -166,7 +166,7 @@ export default {
                 project_name: project_name,
                 created_at: created_at,
             }
-            let project_endpoint = this.$store.state.dev.projects_endpoint + '/get-project'
+            let project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
             axios.post(project_endpoint, request_params).then(response => {
                 let project = response.data
                 project.created_at = moment().utc().format()
@@ -184,7 +184,7 @@ export default {
                 project_name: project_name,
                 created_at: created_at,
             }
-            let project_endpoint = this.$store.state.dev.projects_endpoint + '/get-project'
+            let project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
             axios.post(project_endpoint, request_params).then(response => {
                 let project_loader = {
                     project: response.data,

--- a/src/components/sitepages/SiteCalendar.vue
+++ b/src/components/sitepages/SiteCalendar.vue
@@ -57,10 +57,6 @@ export default {
       utcTime: "-",
 
       showMoonEvents: true,
-
-      // URL for the calendar backend api
-      //backendUrl: 'https://m1vw4uqnpd.execute-api.us-east-1.amazonaws.com',
-      backendUrl: "https://calendar.photonranch.org",
     };
   },
   created() {

--- a/src/components/sitepages/SiteProjects.vue
+++ b/src/components/sitepages/SiteProjects.vue
@@ -45,10 +45,6 @@ export default {
       utcTime: "-",
 
       project_to_load: "",
-
-      // URL for the calendar backend api
-      //backendUrl: 'https://m1vw4uqnpd.execute-api.us-east-1.amazonaws.com',
-      backendUrl: "https://calendar.photonranch.org",
     };
   },
   created() {

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -412,7 +412,7 @@ export default {
     },
 
     created: function() {
-        const url = this.$store.state.dev.active_api + '/all/config' 
+        const url = this.$store.state.api_endpoints.active_api + '/all/config' 
         axios.get(url).then(response => {
             for (let s in response.data) {
                 Vue.set(this.site_info, s, {

--- a/src/components/status/PhaseStatusBar.vue
+++ b/src/components/status/PhaseStatusBar.vue
@@ -62,7 +62,7 @@ export default {
     mounted() {
         this.get_recent_phase_status()
 
-        let datastreamurl = `wss://datastream.photonranch.org/dev` 
+        let datastreamurl = this.$store.state.api_endpoints.datastream 
                         + `?site=${encodeURIComponent(this.site)}`
         this.websocket = new ReconnectingWebSocket(datastreamurl)
         this.websocket.onmessage = msg => {
@@ -89,7 +89,7 @@ export default {
     methods: {
         async get_recent_phase_status() {
             const max_age = 3600  // one hour
-            let url = this.$store.state.dev.status_endpoint 
+            let url = this.$store.state.api_endpoints.status_endpoint 
                 + `/phase_status/${this.site}`
                 + `?max_age_seconds=${encodeURIComponent(max_age)}`
             let latest_phase_status = await axios.get(url)

--- a/src/datastreamer/index.js
+++ b/src/datastreamer/index.js
@@ -8,7 +8,7 @@ const datastreamer = {
 
   open_connection(sitecode) {
     this.close()
-    let datastreamurl = `wss://datastream.photonranch.org/dev` 
+    let datastreamurl = this.$store.state.api_endpoints.datastream 
                       + `?site=${encodeURIComponent(sitecode)}`
     websocket = new ReconnectingWebSocket(datastreamurl)
     websocket.onmessage = msg => {

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -69,7 +69,7 @@ export const commands_mixin = {
       command.mount = this.active_mount
       command.timestamp = parseInt(Date.now() / 1000)
 
-      const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.active_site}`
+      const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.active_site}`
       const options = await this.getAuthHeader()
       axios.post(url, command, options).then(response => {
         this.command_is_sending = false
@@ -92,7 +92,7 @@ export const commands_mixin = {
         console.log('no args')
         form = formCreatorFunction().form
       }
-      const url = `${this.$store.state.dev.jobs_api}/newjob?site=${this.active_site}`
+      const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.active_site}`
 
       form.timestamp = parseInt(Date.now() / 1000)
       form.site = this.active_site

--- a/src/mixins/user_status_mixin.js
+++ b/src/mixins/user_status_mixin.js
@@ -160,7 +160,7 @@ export const user_status_mixin = {
     },
 
     computed: {
-        ...mapState('dev', [
+        ...mapState('api_endpoints', [
             'logs_ws_endpoint',
             'logs_endpoint',
         ]),

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,7 @@ import auth from './modules/auth'
 import site_config from './modules/site_config'
 import images from './modules/images'
 import script_settings from './modules/script_settings'
-import dev from './modules/dev'
+import api_endpoints from './modules/api_endpoints'
 import js9 from './modules/js9'
 import command_params from './modules/command_params'
 import user_data from './modules/user_data'
@@ -33,7 +33,7 @@ const store = new Vuex.Store({
         script_settings,
         images,
         user_data,
-        dev,
+        api_endpoints,
         js9,
         auth,
         calendar,

--- a/src/store/modules/api_endpoints.js
+++ b/src/store/modules/api_endpoints.js
@@ -25,6 +25,8 @@ const state = {
 
     status_endpoint: 'https://status.photonranch.org/status',
     //status_endpoint: 'https://status.photonranch.org/test',
+
+    datastream: "wss://datastream.photonranch.org/dev",
 }
 
 // getters

--- a/src/store/modules/calendar.js
+++ b/src/store/modules/calendar.js
@@ -68,7 +68,7 @@ const actions = {
         }
 
         // Prepare the api call get reservations
-        const url = "https://calendar.photonranch.org/dev/get-event-at-time"
+        const url = this.$store.state.api_endpoints.calendar_api + "/get-event-at-time"
         const iso_datestring = moment.utc().format()
         const request_body = {
             site: site,

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -132,7 +132,7 @@ const actions = {
         }
 
         // Fetch the incoming image
-        let apiName = rootState.dev.active_api;  // Get the base api url
+        let apiName = rootState.api_endpoints.active_api;  // Get the base api url
         let path = `/image/${new_base_filename}`;  
 
         // Make the api call.
@@ -199,7 +199,7 @@ const actions = {
      */
     get_filtered_images({ commit, dispatch, rootState }, filter_params) {
         dispatch('toggle_live_data', false)
-        let apiName = rootState.dev.active_api;
+        let apiName = rootState.api_endpoints.active_api;
         let url = apiName + '/filtered_images';
         let body = { 
             method: "GET",
@@ -224,7 +224,7 @@ const actions = {
 
     get_last_24hrs({ commit, dispatch, rootState}) {
       dispatch('toggle_live_data', false)
-      let apiName = rootState.dev.active_api;
+      let apiName = rootState.api_endpoints.active_api;
       let url = apiName + '/filtered_images';
       let body = { 
           method: "GET",
@@ -258,7 +258,7 @@ const actions = {
     async load_latest_images({ dispatch, commit, state, rootState }, num_images ) {
 
         let site = rootState.site_config.selected_site;
-        let apiName = rootState.dev.active_api;
+        let apiName = rootState.api_endpoints.active_api;
         let querySize = num_images || 25; // How many images to get
         let path = `/${site}/latest_images/${querySize}`;
 
@@ -312,7 +312,7 @@ const actions = {
 
     load_latest_info_images({ state, commit, rootState}) {
       const site = rootState.site_config.selected_site;
-      const base_url = rootState.dev.active_api
+      const base_url = rootState.api_endpoints.active_api
 
       // query each of the three channels
       for (let channel = 0; channel < 3; channel ++) {
@@ -390,7 +390,7 @@ const actions = {
     async get_fits_url({rootState}, {base_filename, data_type, reduction_level}) {
 
         // Get the global configuration for all sites from an api call.
-        const apiName = rootState.dev.active_api
+        const apiName = rootState.api_endpoints.active_api
 
         const path = '/download';
         let body = {

--- a/src/store/modules/js9.js
+++ b/src/store/modules/js9.js
@@ -77,7 +77,7 @@ const actions = {
             }
 
             // Get the url based on the image filename
-            let apiName = rootState.dev.active_api;
+            let apiName = rootState.api_endpoints.active_api;
             let path = '/download';
             let body = {
                 object_name: rootGetters['images/small_fits_filename']

--- a/src/store/modules/script_settings.js
+++ b/src/store/modules/script_settings.js
@@ -358,7 +358,7 @@ const actions = {
      */
     async script_run_command({ getters, rootState }) {
 
-        const url = `${rootState.dev.jobs_api}/newjob?site=${rootState.site_config.selected_site}`
+        const url = `${rootState.api_endpoints.jobs_api}/newjob?site=${rootState.site_config.selected_site}`
         const header = await getAuthHeader()
 
         // Command to send
@@ -415,7 +415,7 @@ const actions = {
     async script_stop_command({ rootState }) {
 
         // API parameters
-        const url = `${rootState.dev.jobs_api}/newjob`//?site=${rootState.site_config.selected_site}`
+        const url = `${rootState.api_endpoints.jobs_api}/newjob`//?site=${rootState.site_config.selected_site}`
         const header = await getAuthHeader()
         let site = rootState.site_config.selected_site;
         let mount = rootState.site_config.selected_mount;

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -245,7 +245,7 @@ const actions = {
      * observatories in the network. 
      */
     update_config({ commit, dispatch, rootState }) {
-        const url = `${rootState.dev.active_api}/all/config`
+        const url = `${rootState.api_endpoints.active_api}/all/config`
         axios.get(url).then(response => {
             commit('setGlobalConfig', response.data)
         }).catch(error => {

--- a/src/store/modules/sitestatus/index.js
+++ b/src/store/modules/sitestatus/index.js
@@ -213,7 +213,7 @@ const actions = {
 
   // Get and update the 'open' status of all sites. Used for the global map site indicators. 
   async getSiteOpenStatus({commit, rootState }) {
-    const url = rootState.dev.status_endpoint + '/allopenstatus'
+    const url = rootState.api_endpoints.status_endpoint + '/allopenstatus'
     const response = await Axios.get(url)
     commit('siteOpenStatus', response.data)
   },
@@ -227,7 +227,7 @@ const actions = {
       dispatch('clearStatus')
     }
 
-    let url = rootState.dev.status_endpoint + `/${current_site}/complete_status`
+    let url = rootState.api_endpoints.status_endpoint + `/${current_site}/complete_status`
     let response = await Axios.get(url)
 
     // If the site has no status available, commit a default empty status to the store

--- a/src/store/modules/user_data.js
+++ b/src/store/modules/user_data.js
@@ -52,7 +52,7 @@ const actions = {
 
         commit('user_projects_is_loading', true)
 
-        const url = rootState.dev.projects_endpoint + '/get-user-projects'
+        const url = rootState.api_endpoints.projects_endpoint + '/get-user-projects'
         const body = {user_id: user_id}
         let header = await getAuthRequestHeader()
 
@@ -70,7 +70,7 @@ const actions = {
         
         commit('all_projects_is_loading', true)
 
-        const url = rootState.dev.projects_endpoint + '/get-all-projects'
+        const url = rootState.api_endpoints.projects_endpoint + '/get-all-projects'
         const body = {}
         let header = await getAuthRequestHeader()
 
@@ -86,7 +86,7 @@ const actions = {
     fetchUserEvents({ commit, rootState }, user_id) {
         commit('user_events_is_loading', true)
 
-        const url = rootState.dev.calendar_api + '/user-events-ending-after-time'
+        const url = rootState.api_endpoints.calendar_api + '/user-events-ending-after-time'
         const header = {
             'headers': {
                 'Content-Type': 'application/json;charset=UTF-8',
@@ -107,7 +107,7 @@ const actions = {
     },
 
     async deleteProject({ dispatch, rootState }, {project_name,created_at}) {
-        const url = rootState.dev.projects_endpoint + '/delete-project'
+        const url = rootState.api_endpoints.projects_endpoint + '/delete-project'
         let header = await getAuthRequestHeader()
         let body = {
             project_name:project_name,
@@ -138,7 +138,7 @@ const actions = {
     updateProjectInEvent({ dispatch, rootState }, {event, project_name,created_at}) {
         /* arg 'event' is the event object we want to update. Must include 'event_id' and 'start' */
 
-        const url = rootState.dev.calendar_api + '/add-projects-to-events'
+        const url = rootState.api_endpoints.calendar_api + '/add-projects-to-events'
 
         const header = {
             'headers': {

--- a/src/store/modules/userstatus.js
+++ b/src/store/modules/userstatus.js
@@ -33,7 +33,7 @@ const actions = {
         if (site_param == "") { return }
 
         // Form the url with query params
-        let url = rootState.dev.logs_endpoint + '/recent-logs'
+        let url = rootState.api_endpoints.logs_endpoint + '/recent-logs'
         url += '?after_time=' + encodeURIComponent(after_time_param)
         url += '&site=' + encodeURIComponent(site_param)
 

--- a/src/views/JobsMonitor.vue
+++ b/src/views/JobsMonitor.vue
@@ -86,7 +86,7 @@ export default {
       form.site="wmd"
       form.mount="mount1"
       form.instance="camera1"
-      const url = `${this.$store.state.dev.jobs_api}/newjob?site=${form.site}`
+      const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${form.site}`
       axios.post(url, form, options)
         .then(console.log)
         .catch(console.warn)
@@ -94,7 +94,7 @@ export default {
 
     getJobs() {
       let that = this
-      const url = `${this.$store.state.dev.jobs_api}/getrecentjobs`
+      const url = `${this.$store.state.api_endpoints.jobs_api}/getrecentjobs`
       let body = {
         "site": "wmd",
         "timeRange": 86400*1000*24/24

--- a/src/views/PlanTargets.vue
+++ b/src/views/PlanTargets.vue
@@ -131,7 +131,7 @@ export default {
     },
   },
   created: function() {
-    const url = "https://api.photonranch.org/api/all/config"
+    const url = this.$store.state.api_endpoints.active_api + "/all/config"
     axios.get(url).then(response => {
       for (let site in response.data) {
         Vue.set(this.site_info, site, {

--- a/src/views/Remotehq.vue
+++ b/src/views/Remotehq.vue
@@ -32,7 +32,7 @@ export default {
   },
   methods: {
       async get_remote_browser() {
-        const url = this.$store.state.dev.active_api + '/new_remotehq_browser'
+        const url = this.$store.state.api_endpoints.active_api + '/new_remotehq_browser'
         let token = await this.$auth.getTokenSilently();
         let headers = {
             'headers': {
@@ -48,7 +48,7 @@ export default {
 
       },
       async requires_auth_test() {
-        const url = this.$store.state.dev.active_api + '/dummy-requires-auth'
+        const url = this.$store.state.api_endpoints.active_api + '/dummy-requires-auth'
         let token = await this.$auth.getTokenSilently();
         let headers = {
             'headers': {

--- a/src/views/btns.vue
+++ b/src/views/btns.vue
@@ -231,7 +231,7 @@ export default {
       isLoggedIn: 'isLoggedIn',
       token: 'getToken',
     }),
-    ...mapGetters('dev', [
+    ...mapGetters('api_endpoints', [
       'api',
     ])
   },


### PR DESCRIPTION
This pull request renames `dev.js` to `api_endpoints.js` - if a different name is better, it'll be easier to find and replace now. This also changes all hardcoded API calls to reference `api_endpoints.js` instead as well as adds a datastream url to `api_endpoints.js`.

Some notes: `UserEventsTable.vue`, `SiteCalendar.vue`, and `SiteProjects.vue` all made reference to an API endpoint that didn't exist (and then...didn't use that for anything in the code), so those references have been removed entirely. 

`LogStream.vue` and `user_status_mixin.js` make use of a `logs_ws_endpoint` that's theoretically defined in `api_endpoints.js`, but no such store value exists. Should this be changed to a different value/endpoint, or is there something I'm not seeing? (Or is this code just unused?)