### PR TITLE
Feature/camera changes

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -9,6 +9,20 @@
       >
         Autofocus
       </b-button>
+      <b-button
+        class="button is-outlined"
+        style="margin-bottom: 1em;"
+        @click="postCommand(focus_adjust_command)"
+      >
+        Focus Adjust
+      </b-button>
+      <b-button
+        class="button is-outlined"
+        style="margin-bottom: 1em;"
+        @click="postCommand(zcompress_command)"
+      >
+        Z-Compress
+      </b-button>
       <b-field
         label-position="on-border"
         label="selected:"

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -167,6 +167,19 @@
 
     <b-field
       horizontal
+      label="Smart Stack"
+    >
+      <b-switch
+        v-model="smartstackIsActive"
+        size="is-small"
+        type="is-info"
+      >
+        {{ smartstackIsActive ? "Smart stack is active" : "Smart stack not active" }}
+      </b-switch>
+    </b-field>
+
+    <b-field
+      horizontal
       label="Subframe"
     >
       <b-switch
@@ -343,6 +356,11 @@ export default {
 
     number_of_cameras () {
       return Object.keys(this.available_devices('camera', this.sitecode)).length
+    },
+
+    smartstackIsActive: {
+      get () { return this.$store.getters['command_params/smartstackIsActive'] },
+      set (val) { this.$store.commit('command_params/smartstackIsActive', val) }
     },
 
     subframe_is_active: {

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -138,11 +138,8 @@
     <CameraBinSelectField
       v-if="camera_can_bin"
       v-model="camera_bin"
-      :bin-modes="camera_bin_options"
-      :default="camera_default_bin"
       :horizontal="true"
     />
-
     <b-field
       v-if="camera_areas && camera_areas.length != 0"
       horizontal
@@ -343,7 +340,6 @@ export default {
       'selected_camera_config',
       'camera_has_darkslide',
       'camera_can_bin',
-      'camera_default_bin'
     ]),
 
     number_of_cameras () {

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -353,7 +353,7 @@ export default {
       'available_devices',
       'selected_camera_config',
       'camera_has_darkslide',
-      'camera_can_bin',
+      'camera_can_bin'
     ]),
 
     number_of_cameras () {

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -180,23 +180,15 @@
 
     <b-field
       horizontal
-      label="Subframe"
+      label="Long Stack"
     >
       <b-switch
-        v-model="subframe_is_active"
+        v-model="longstackIsActive"
         size="is-small"
         type="is-info"
       >
-        {{ subframe_is_active ? "Subframe is active" : "Subframe not active" }}
+        {{ longstackIsActive ? "Long stack is active" : "Long stack not active" }}
       </b-switch>
-    </b-field>
-    <b-field
-      horizontal
-      label=""
-    >
-      <p class="is-size-7">
-        subframe: ({{ subframe_x0.toFixed(2) }},{{ subframe_y0.toFixed(2) }}), ({{ subframe_x1.toFixed(2) }}, {{ subframe_y1.toFixed(2) }})
-      </p>
     </b-field>
 
     <b-field
@@ -361,6 +353,11 @@ export default {
     smartstackIsActive: {
       get () { return this.$store.getters['command_params/smartstackIsActive'] },
       set (val) { this.$store.commit('command_params/smartstackIsActive', val) }
+    },
+
+    longstackIsActive: {
+      get () { return this.$store.getters['command_params/longstackIsActive'] },
+      set (val) { this.$store.commit('command_params/longstackIsActive', val) }
     },
 
     subframe_is_active: {

--- a/src/components/InstrumentControls/Telescope.vue
+++ b/src/components/InstrumentControls/Telescope.vue
@@ -316,7 +316,6 @@ export default {
         this.send_site_command(move_telescope_command_params).then(
           (response) => {
             this.send_site_command(camera_expose_command_params)
-            console.log(camera_expose_command_params)
           }
         )
       }

--- a/src/components/InstrumentControls/Telescope.vue
+++ b/src/components/InstrumentControls/Telescope.vue
@@ -316,6 +316,7 @@ export default {
         this.send_site_command(move_telescope_command_params).then(
           (response) => {
             this.send_site_command(camera_expose_command_params)
+            console.log(camera_expose_command_params)
           }
         )
       }

--- a/src/components/InstrumentControls/instrumentFields/CameraBinSelectField.vue
+++ b/src/components/InstrumentControls/instrumentFields/CameraBinSelectField.vue
@@ -1,20 +1,17 @@
 <template>
   <b-field
     :horizontal="horizontal"
-    label="Bin"
+    label="Resolution"
   >
     <b-select
       v-model="localSelection"
-      placeholder="Select bin"
       size="is-small"
     >
-      <option
-        v-for="(bin_option, index) in binModes"
-        :key="index"
-        :value="bin_option"
-        :selected="index === 0"
-      >
-        {{ bin_option | bin_option_display }}
+      <option value="optimal" selected>
+        Optimal
+      </option>
+       <option value="maximum">
+        Maximum
       </option>
     </b-select>
   </b-field>
@@ -24,36 +21,21 @@
 export default {
   name: 'CameraBinSelectField',
   props: {
-    binModes: {
-      type: Array,
-      default: () => [],
-      validator: bins => {
-        // Ensure all elements are arrays
-        return bins.every(item => Array.isArray(item))
-      }
-    },
-    value: {},
     horizontal: {
       type: Boolean,
       default: false
     },
-    default: {
-      type: Array,
-      default: () => []
-    }
   },
-  filters: {
-    bin_option_display (val) {
-      if (val.length == 3) {
-        return `[${val[0]}, ${val[1]}] -- pix size ${val[2]} arcsec`
-      }
-      else return val
-    }
-  },
+
   computed: {
     localSelection: {
       get () {
-        return this.value
+        // If no default gets set, make sure default is optimal
+          if (this.value) {
+            return this.value
+          } else {
+            return "optimal"
+          }
       },
       set (val) {
         this.$emit('input', val)

--- a/src/components/InstrumentControls/instrumentFields/CameraBinSelectField.vue
+++ b/src/components/InstrumentControls/instrumentFields/CameraBinSelectField.vue
@@ -7,10 +7,13 @@
       v-model="localSelection"
       size="is-small"
     >
-      <option value="optimal" selected>
+      <option
+        value="optimal"
+        selected
+      >
         Optimal
       </option>
-       <option value="maximum">
+      <option value="maximum">
         Maximum
       </option>
     </b-select>
@@ -24,18 +27,18 @@ export default {
     horizontal: {
       type: Boolean,
       default: false
-    },
+    }
   },
 
   computed: {
     localSelection: {
       get () {
         // If no default gets set, make sure default is optimal
-          if (this.value) {
-            return this.value
-          } else {
-            return "optimal"
-          }
+        if (this.value) {
+          return this.value
+        } else {
+          return 'optimal'
+        }
       },
       set (val) {
         this.$emit('input', val)

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -351,26 +351,17 @@
               </option>
             </b-select>
           </b-field>
-          <b-field :label="n==1 ? 'Bin' : ''">
+          <b-field :label="n==1 ? 'Resolution' : ''">
             <b-select
               v-model="exposures[n-1].bin"
               size="is-small"
               :disabled="!exposures[n-1].active"
             >
-              <option value="0, 0">
-                default
+              <option value="optimal">
+                Optimal
               </option>
-              <option value="1, 1">
-                1, 1
-              </option>
-              <option value="2, 2">
-                2, 2
-              </option>
-              <option value="3, 3">
-                3, 3
-              </option>
-              <option value="4, 4">
-                4, 4
+              <option value="maximum">
+                Maximum
               </option>
             </b-select>
           </b-field>
@@ -837,7 +828,7 @@ export default {
           exposure: 1,
           filter: 'Lum',
           area: 'FULL',
-          bin: '0, 0',
+          bin: 'optimal',
           dither: 'no',
           photometry: '-',
           defocus: 0
@@ -994,7 +985,7 @@ export default {
           exposure: 1,
           filter: 'Lum',
           area: 'FULL',
-          bin: '0, 0',
+          bin: 'optimal',
           dither: 'no',
           photometry: '-',
           defocus: 0

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -175,6 +175,14 @@
           </template>
           <b-checkbox v-model="targets.hrsminssecs" />
         </b-field>
+
+        <b-field style="margin-left: 2em;" label = "Smart Stack">
+          <b-checkbox v-model="smartstackIsActive" />
+        </b-field>
+
+        <b-field style="margin-left: 2em;" label = "Long Stack">
+          <b-checkbox v-model="longstackIsActive" />
+        </b-field>
       </div>
 
       <!-- Multi-select dropdown, choose which sites a project can be scheduled at -->
@@ -1128,7 +1136,10 @@ export default {
         // Empty nested arrays such that
         // project_data[exposure_index] = [array of filenames]
         project_data: this.exposures.map(e => []),
-        scheduled_with_events: this.project_events
+        scheduled_with_events: this.project_events,
+        // Stacking options
+        smartstack: this.smartstackIsActive,
+        longstack: this.longstackIsActive
       }
       // Make sure all warnings are false, otherwise don't create the project.
       if (Object.values(this.warn).every(x => !x)) {
@@ -1180,7 +1191,10 @@ export default {
         // Empty nested arrays such that
         // project_data[target_index][exposure_index] = [array of filenames]
         project_data: this.exposures.map(e => []),
-        scheduled_with_events: this.project_events
+        scheduled_with_events: this.project_events,
+        // Stacking options
+        smartstack: this.smartstackIsActive,
+        longstack: this.longstackIsActive
       }
       const request_body = {
         project_name: this.loaded_project_name,
@@ -1289,6 +1303,17 @@ export default {
       'user_events',
       'user_projects'
     ]),
+
+    smartstackIsActive: {
+      get () { return this.$store.getters['command_params/smartstackIsActive'] },
+      set (val) { this.$store.commit('command_params/smartstackIsActive', val) }
+    },
+
+    longstackIsActive: {
+      get () { return this.$store.getters['command_params/longstackIsActive'] },
+      set (val) { this.$store.commit('command_params/longstackIsActive', val) }
+    },
+
     user_events_with_projects () {
       return this.user_events
         .filter(event => event.project_id == 'none')

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -176,11 +176,17 @@
           <b-checkbox v-model="targets.hrsminssecs" />
         </b-field>
 
-        <b-field style="margin-left: 2em;" label = "Smart Stack">
+        <b-field
+          style="margin-left: 2em;"
+          label="Smart Stack"
+        >
           <b-checkbox v-model="smartstackIsActive" />
         </b-field>
 
-        <b-field style="margin-left: 2em;" label = "Long Stack">
+        <b-field
+          style="margin-left: 2em;"
+          label="Long Stack"
+        >
           <b-checkbox v-model="longstackIsActive" />
         </b-field>
       </div>

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -35,9 +35,7 @@ export default {
 
     // set default values from config
     // TODO: this should go in a better place
-    this.camera_bin = this.camera_default_bin
     this.camera_areas_selection = this.camera_default_area
-    this.camera_bin = this.camera_default_bin
   },
 
   beforeDestroy () {
@@ -62,7 +60,6 @@ export default {
   },
 
   computed: {
-
     ...mapGetters('images', [
       'current_image'
     ]),
@@ -71,7 +68,6 @@ export default {
     ]),
 
     ...mapGetters('site_config', [
-      'camera_default_bin',
       'camera_default_area'
     ]),
 

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -109,6 +109,11 @@ export default {
       set (val) { this.$store.commit('command_params/smartstackIsActive', val) }
     },
 
+    longstackIsActive: {
+      get () { return this.$store.getters['command_params/longstackIsActive'] },
+      set (val) { this.$store.commit('command_params/longstackIsActive', val) }
+    },
+
     subframeIsActive: {
       get () { return this.$store.getters['command_params/subframeIsActive'] },
       set (val) { this.$store.commit('command_params/subframeIsActive', val) }

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -104,6 +104,11 @@ export default {
       set (val) { this.$store.commit('command_params/telescope_coordinate_frame', val) }
     },
 
+    smartstackIsActive: {
+      get () { return this.$store.getters['command_params/smartstackIsActive'] },
+      set (val) { this.$store.commit('command_params/smartstackIsActive', val) }
+    },
+
     subframeIsActive: {
       get () { return this.$store.getters['command_params/subframeIsActive'] },
       set (val) { this.$store.commit('command_params/subframeIsActive', val) }

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -220,8 +220,8 @@ export const commands_mixin = {
         },
         {
           filter: this.filter_wheel_options_selection,
-          bin: this.camera_bin,
-        },
+          bin: this.camera_bin
+        }
       )
     },
     focus_adjust_command () {
@@ -232,15 +232,15 @@ export const commands_mixin = {
         {},
         {
           filter: this.filter_wheel_options_selection,
-          bin: this.camera_bin,
-        },
+          bin: this.camera_bin
+        }
       )
     },
     zcompress_command () {
       return this.base_command(
         'focuser',
         'zcompress',
-        '',
+        ''
       )
     },
     mount_slew_clickposition_command (x, y, filename) {
@@ -425,7 +425,7 @@ export const commands_mixin = {
         time: this.camera_exposure,
         image_type: this.camera_image_type,
         smartstack: this.smartstackIsActive,
-        longstack: this.longstackIsActive,
+        longstack: this.longstackIsActive
       }
       const opt_params = {
         count: this.camera_count.toString(),

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -267,6 +267,7 @@ export const commands_mixin = {
       'telescope_coordinate_frame',
 
       'smartstackIsActive',
+      'longstackIsActive',
 
       'subframeIsActive',
       'subframeDefinedWithFile',
@@ -401,7 +402,9 @@ export const commands_mixin = {
     camera_expose_command () {
       const req_params = {
         time: this.camera_exposure,
-        image_type: this.camera_image_type
+        image_type: this.camera_image_type,
+        smartstack: this.smartstackIsActive,
+        longstack: this.longstackIsActive,
       }
       const opt_params = {
         count: this.camera_count.toString(),

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -218,7 +218,29 @@ export const commands_mixin = {
         {
           ...num_focus_pts && { num_focus_pts }
         },
-        {}
+        {
+          filter: this.filter_wheel_options_selection,
+          bin: this.camera_bin,
+        },
+      )
+    },
+    focus_adjust_command () {
+      return this.base_command(
+        'focuser',
+        'focusadjust',
+        '',
+        {},
+        {
+          filter: this.filter_wheel_options_selection,
+          bin: this.camera_bin,
+        },
+      )
+    },
+    zcompress_command () {
+      return this.base_command(
+        'focuser',
+        'zcompress',
+        '',
       )
     },
     mount_slew_clickposition_command (x, y, filename) {
@@ -607,7 +629,7 @@ export const commands_mixin = {
     },
 
     filter_wheel_command () {
-      return this.base_command('filter_wheel', 'set_name', 'apply',
+      return this.base_command('filter_wheel', 'set_name', 'Apply',
         { filter_name: this.filter_wheel_options_selection }
       )
     },

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -266,6 +266,8 @@ export const commands_mixin = {
       'telescope_selection',
       'telescope_coordinate_frame',
 
+      'smartstackIsActive',
+
       'subframeIsActive',
       'subframeDefinedWithFile',
 

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -23,18 +23,17 @@ export const commands_mixin = {
       // Camera Fields
       camera_image_type_options: [
         'light',
+        'simulation',
         'experimental',
         'bias',
         'dark',
-        'autofocus probe',
         'screen flat',
         'sky flat',
         'lamp flat',
         'arc flat',
         'NeAr flat',
         'ThAr flat',
-        'solar flat',
-        'simulation'
+        'solar flat'
       ],
       telescope_coordinate_frame_options: [
         'ICRS',

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -32,7 +32,7 @@ const state = {
   camera_exposure: '1',
   camera_count: 1, // numberinput form requires number, not string. converted to string in expose command.
   camera_area: null,
-  camera_bin: [1, 1],
+  camera_bin: 'optimal',
   camera_dither: 'off',
   camera_extract: 'on', // requested by Wayne for SEP related tests 20200413
   camera_image_type: 'light',

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -20,6 +20,7 @@ const state = {
 
   // Stack parameters
   smartstackIsActive: true,
+  longstackIsActive: false,
 
   // Subframe parameters
   subframeIsActive: false,
@@ -66,6 +67,7 @@ const getters = {
   telescope_coordinate_frame: state => state.telescope_coordinate_frame,
 
   smartstackIsActive: state => state.smartstackIsActive,
+  longstackIsActive: state => state.longstackIsActive,
 
   subframeIsActive: state => state.subframeIsActive,
   subframeDefinedWithFile: state => state.subframeDefinedWithFile,
@@ -139,6 +141,7 @@ const mutations = {
   telescope_coordinate_frame (state, val) { state.telescope_coordinate_frame = val },
 
   smartstackIsActive (state, val) { state.smartstackIsActive = val },
+  longstackIsActive (state, val) { state.longstackIsActive = val },
 
   subframeIsActive (state, val) { state.subframeIsActive = val },
   subframeDefinedWithFile (state, val) { state.subframeDefinedWithFile = val },

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -18,6 +18,9 @@ const state = {
   telescope_selection: 1, // 1: main telescope, 2: auxiliary telescope
   telescope_coordinate_frame: 'ICRS',
 
+  // Stack parameters
+  smartstackIsActive: true,
+
   // Subframe parameters
   subframeIsActive: false,
   subframeDefinedWithFile: '',
@@ -61,6 +64,8 @@ const getters = {
 
   telescope_selection: state => state.telescope_selection,
   telescope_coordinate_frame: state => state.telescope_coordinate_frame,
+
+  smartstackIsActive: state => state.smartstackIsActive,
 
   subframeIsActive: state => state.subframeIsActive,
   subframeDefinedWithFile: state => state.subframeDefinedWithFile,
@@ -132,6 +137,8 @@ const mutations = {
 
   telescope_selection (state, val) { state.telescope_selection = val },
   telescope_coordinate_frame (state, val) { state.telescope_coordinate_frame = val },
+
+  smartstackIsActive (state, val) { state.smartstackIsActive = val },
 
   subframeIsActive (state, val) { state.subframeIsActive = val },
   subframeDefinedWithFile (state, val) { state.subframeDefinedWithFile = val },

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -27,7 +27,7 @@ const state = {
   selected_sequencer: '',
 
   selector_exists: false,
-  selected_selector: '',
+  selected_selector: ''
 }
 
 const getters = {

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -27,7 +27,7 @@ const state = {
   selected_sequencer: '',
 
   selector_exists: false,
-  selected_selector: ''
+  selected_selector: '',
 }
 
 const getters = {
@@ -179,9 +179,6 @@ const getters = {
   },
   camera_has_darkslide: (state, getters) => {
     return getters.selected_camera_config.settings?.has_darkslide ?? false
-  },
-  camera_default_bin: (state, getters) => {
-    return getters.selected_camera_config.settings?.default_bin ?? getters.camera_bin_options[0] ?? ''
   },
 
   // Available filters


### PR DESCRIPTION
This pull request does a few things on the camera tab:

1. Adds toggle-able "smart stack" (default on) and "long stack" (default off) options to the camera tab and project parameters, to be handled in the observatory code.
2. Removes subframe options in camera tab.
3. Reorders image type dropdown.
4. Changes binning from numerical values to one of two string options: "optimal" (default for all cameras, instead of an individual default determined by site config) and "maximum" in both the camera tab and project parameters. Note that this is in place of numerical values, not in addition to.
5. Adds "Focus Adjust" and "Z-Compress" buttons to camera tab. Each posts a new job, with the actions named `"focusadjust"` and `"zcompress"` respectively. Both `"focusadjust"` and `"autofocus"` now also pass along the filter and (updated) binning as optional parameters.

