### PR TITLE
Better night log reset when switching sites

### DIFF
--- a/src/components/NightLog.vue
+++ b/src/components/NightLog.vue
@@ -168,7 +168,6 @@ export default {
   },
   watch: {
     $route (to, from) {
-      console.log('route changed')
       this.resetNightLogState()
     }
   },

--- a/src/components/NightLog.vue
+++ b/src/components/NightLog.vue
@@ -166,7 +166,22 @@ export default {
     $('#night-log-draggable-note').draggable({ cancel: 'article section.message-body' })
     $('#night-log-draggable-editor').draggable({ cancel: 'article section.message-body' })
   },
+  watch: {
+    $route (to, from) {
+      console.log('route changed')
+      this.resetNightLogState()
+    }
+  },
   methods: {
+    resetNightLogState () {
+      this.noteVisible = false
+      this.editorVisible = false
+      this.noteIsLoaded = false
+      this.deleteInProgress = false
+      this.createNoteInProgress = false
+      this.note = ''
+      this.getNote()
+    },
     getNote () {
       const url = this.$store.state.api_endpoints.active_api + '/nightlog/' + this.site
       axios.get(url).then(response => {


### PR DESCRIPTION
If the user navigated to a new site using the menu (not editing the url directly), the night log from the old site would persist into the new one. 

This PR offers a cleaner reset and reload of the night log state with a watcher that runs whenever the route changes. 