### PR TITLE
Feature/site overview cards

### DIFF
--- a/src/components/SitesOverviewCards.vue
+++ b/src/components/SitesOverviewCards.vue
@@ -99,11 +99,6 @@ export default {
 
   computed: {
     orderedSites () {
-      if (!this.siteImages) {
-        console.warn('no site images')
-        return this.sites
-      }
-
       const getImgDate = (site) => {
         const sitecode = site.site
         if (this.siteImages !== 'undefined' && sitecode in this.siteImages) {
@@ -122,7 +117,6 @@ export default {
       sitesCopy.sort((a, b) => {
         return getImgDate(b) - getImgDate(a)
       })
-      console.log(sitesCopy.map(s => getImgDate(s)))
       return sitesCopy
     }
   }

--- a/src/components/SitesOverviewCards.vue
+++ b/src/components/SitesOverviewCards.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="card-row">
-    <template v-for="s in sites">
+    <template v-for="s in orderedSites">
       <div
+        v-if="siteImagesLoaded"
         :key="s.site"
         :val="s.site"
         class="card"
@@ -9,18 +10,20 @@
           'online': isOnline(s.site)
         }"
       >
+        <div class="card-image">
+          <router-link :to="'/site/'+s.site+'/observe'">
+            <figure class="image is-2by1">
+              <img :src="getImageUrl(s.site)">
+            </figure>
+          </router-link>
+        </div>
         <div class="card-header subtitle">
           <router-link :to="'/site/'+s.site+'/observe'">
             <span style="color: white; height: 2em;">{{ s.name }}</span>
           </router-link>
         </div>
-
-        <div class="card-image">
-          <router-link :to="'/site/'+s.site+'/observe'">
-            <figure class="image is-2by1">
-              <img :src="site_images[s.site]">
-            </figure>
-          </router-link>
+        <div class="site-code">
+          {{ s.site }}
         </div>
       </div>
     </template>
@@ -30,7 +33,6 @@
 <script>
 import axios from 'axios'
 import _ from 'lodash'
-import { mapGetters } from 'vuex'
 
 export default {
   name: 'SitesOverviewCards',
@@ -42,10 +44,9 @@ export default {
   },
   data () {
     return {
-      site_blacklist: ['ALI-sim', 'wmd2'], // don't show test sites
-      site_online_status: {},
-
-      site_images: {}
+      siteOnlineStatus: {},
+      siteImages: {},
+      siteImagesLoaded: false
     }
   },
   mounted () {
@@ -53,7 +54,9 @@ export default {
 
     // Draw observatories with colors to denote weather/open status
     this.getSiteOpenStatus()
-    this.siteOnlineStatusInterval = setInterval(this.getSiteOpenStatus, 5000)
+
+    // Disable the constant polling, since we're not using the online status here for now
+    // this.siteOnlineStatusInterval = setInterval(this.getSiteOpenStatus, 5000)
   },
   beforeDestroy () {
     clearInterval(this.siteOnlineStatusInterval)
@@ -64,31 +67,64 @@ export default {
     }
   },
   methods: {
+    getImageUrl (site) {
+      if (site in this.siteImages) {
+        return this.siteImages[site]
+      } else {
+        return 'https://placehold.jp/30/222222/999999/600x300.png?text=no%20available%20images'
+      }
+    },
     getSiteOpenStatus () {
       const url = this.$store.state.api_endpoints.status_endpoint + '/allopenstatus'
       axios.get(url).then(resp => {
-        this.site_online_status = _.orderBy(resp.data, [s => s.site], ['asc'])
+        this.siteOnlineStatus = _.orderBy(resp.data, [s => s.site], ['asc'])
       })
     },
     isOnline (site) {
-      if (!Object.keys(this.site_online_status).includes(site)) {
+      if (!Object.keys(this.siteOnlineStatus).includes(site)) {
         return false
       }
-      const max_online_age = 300 // 5 minutes
-      const site_status = this.site_online_status[site]
-      const a = site_status.status_age_s <= max_online_age && site_status.weather_ok && site_status.open_ok
+      const maxOnlineAge = 300 // 5 minutes
+      const siteStatus = this.siteOnlineStatus[site]
+      const a = siteStatus.status_age_s <= maxOnlineAge && siteStatus.weather_ok && siteStatus.open_ok
       return a
     },
-    updateAllSiteImages () {
+    async updateAllSiteImages () {
       const url = this.$store.state.api_endpoints.active_api + '/latest_image_all_sites'
-      axios.get(url).then(response => {
-        this.site_images = response.data
-      })
+      const response = await axios.get(url)
+      this.siteImages = response.data
+      this.siteImagesLoaded = true
     }
   },
 
   computed: {
-    ...mapGetters('site_config', ['all_sites_real'])
+    orderedSites () {
+      if (!this.siteImages) {
+        console.warn('no site images')
+        return this.sites
+      }
+
+      const getImgDate = (site) => {
+        const sitecode = site.site
+        if (this.siteImages !== 'undefined' && sitecode in this.siteImages) {
+          const url = this.siteImages[sitecode]
+          const yearmonthday = parseInt(url.split('-')[3])
+          return yearmonthday
+        } else {
+          // This is used for sorting dates, newest to oldest.
+          // If there's no image, we want the site to be placed last.
+          return 0
+        }
+      }
+      // copy the sites array; avoid mutating the prop
+      const sitesCopy = [...this.sites]
+
+      sitesCopy.sort((a, b) => {
+        return getImgDate(b) - getImgDate(a)
+      })
+      console.log(sitesCopy.map(s => getImgDate(s)))
+      return sitesCopy
+    }
   }
 
 }
@@ -101,6 +137,7 @@ export default {
   display:flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 1rem;
   @include tablet {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -109,11 +146,28 @@ export default {
 }
 
 .subtitle {
+  position:absolute;
+  top: 0em;
+  opacity: 80%;
+  pointer-events: none;
   font-size: 1rem;
   padding: 0.25em;
   line-height: 1.25;
-  height: 3em;
+  //height: 3em;
+  width: 100%;
   margin-bottom: 0 !important;
+}
+
+.site-code {
+  position:absolute;
+  height: 0;
+  right: 1rem;
+  bottom: 3.5rem;
+  text-transform:uppercase;
+  font-weight: 900;
+  font-size:xx-large;
+  opacity: 30%;
+
 }
 
 .quick-links {
@@ -130,6 +184,8 @@ export default {
 }
 img {
   object-fit:cover;  // crop, don't distort
+  background-color: black;
+  border: none;
 }
 
 .divider {

--- a/src/components/maps/TheWorldMap.vue
+++ b/src/components/maps/TheWorldMap.vue
@@ -9,7 +9,6 @@
 
 <script>
 import nite from './nite-overlay'
-import axios from 'axios'
 import { mapState, mapGetters, mapActions } from 'vuex'
 import google_map_styles from './google-styles'
 import { makeIcon } from './mapHelpers'

--- a/src/components/maps/TheWorldMap.vue
+++ b/src/components/maps/TheWorldMap.vue
@@ -56,19 +56,6 @@ export default {
 
   methods: {
 
-    async get_global_config () {
-      const url = `${this.$store.state.api_endpoints.active_api}/all/config`
-      return new Promise((resolve, reject) => {
-        axios.get(url)
-          .then(response => {
-            resolve(response.data)
-          })
-          .catch(error => {
-            reject(error)
-          })
-      })
-    },
-
     addMarkerWithData (markerData) {
       const white = { r: 255, g: 255, b: 255 }
       const marker = new google.maps.Marker({
@@ -88,6 +75,9 @@ export default {
             showName ? markerData.name : false),
           scaledSize: new google.maps.Size(23 * sizeCoefficient, 32 * sizeCoefficient) // makes SVG icons work in IE
         })
+
+        // Prevent users from repositioning markers
+        marker.setDraggable(false)
       })
       this.oms.addMarker(marker, e => {
         this.iw.setContent(markerData.content)


### PR DESCRIPTION
Two changes here:

1. Very minor: prevent google map site markers from being dragged and repositioned.
2. Update the site overview cards (that show up under the google map). 
- More space efficient layout, with the addition of the site abbreviation 
- Ordered by most recent activity (measured by the date of the recent image). Sites with no images are shown last. 
- Cleaned up the loading routine to decrease API calls and visible layout changes as the data is loading. Should all happen at once now. 