### PR TITLE
Improve observatory log handling

### DIFF
--- a/src/components/status/SiteStatusFooter.vue
+++ b/src/components/status/SiteStatusFooter.vue
@@ -50,7 +50,7 @@
             <b-tooltip
               position="is-top"
               type="is-dark"
-              :label="''/*timezone timestamp_to_date(log.timestamp)*/"
+              :label="readable_time_ago(log.timestamp)"
             >
               <span class="log-timestamp">{{ timestamp_to_logdate(log.timestamp) }}</span>
             </b-tooltip>
@@ -533,7 +533,9 @@ export default {
       }
       // Otherwise show all the logs
       else {
-        return this.user_status_logs
+        // Only show the latest 100 so the rendering doesn't cause lags.
+        const logs_list = this.user_status_logs.slice(-100)
+        return logs_list
       }
     }
   }
@@ -576,6 +578,7 @@ $log-info: #eee;
 $log-warning: $ptr-yellow;
 $log-error: $ptr-blue;
 $log-critical: $ptr-red;
+$log-stale: grey;
 
 .status-bar-1 {
   //padding-left: $left-padding;
@@ -672,6 +675,9 @@ pre.log-message.error {
 pre.log-message.critical {
   color: $log-critical;
   font-weight: bold;
+}
+pre.log-message.log-is-stale {
+  color: $log-stale;
 }
 
 // New messages enter yellow to grab attention, then fade to their

--- a/src/store/modules/userstatus.js
+++ b/src/store/modules/userstatus.js
@@ -18,13 +18,13 @@ const mutations = {
 
 const actions = {
 
-  // Fetch logs from the last day to display them in the log window
+  // Fetch logs from the previous hour to display them in the log window
   // in chronological order (newest at bottom)
   fetch_recent_logs ({ rootState, commit }) {
-    // Fetch any logs that are under a day old
-    const seconds_per_day = 86400
-    const timestamp_seconds = Math.floor(Date.now() / 1000)
-    const after_time_param = timestamp_seconds - seconds_per_day
+    // Fetch any logs that are under an hour old
+    const max_age_s = 3600
+    const timestamp_s = Math.floor(Date.now() / 1000)
+    const after_time_param = timestamp_s - max_age_s
 
     // Only fetch logs from the current site
     const site_param = rootState.site_config.selected_site


### PR DESCRIPTION
Stale messages (older than 30 minutes) will be prefixed with `(stale)` and colored grey. 

The sluggish expansion of the log messages has been greatly reduced by decreasing the number of log messages rendered to the DOM. The page load only fetches logs from the last hour (instead of the last day), and only 100 at most are actually rendered. 

The tooltip on the log timestamps will now display a readable relative time, like "5 minutes ago".