### PR TITLE
Change to expect header ra units in hours

### DIFF
--- a/src/components/ImageDisplay/ImageInfoBar.vue
+++ b/src/components/ImageDisplay/ImageInfoBar.vue
@@ -15,7 +15,7 @@
       style="display:flex"
     >
       ra:&nbsp;<ra-display
-        :ra_hours_decimal="ra_hours"
+        :ra_hours_decimal="raHours"
         :decimal_precision="3"
       />
     </div>
@@ -74,9 +74,6 @@ export default {
   },
 
   filters: {
-    dateToUnix (date) {
-      return (new Date(date).getTime() / 1000).toFixed(0)
-    },
     dateToReadable (date) {
       return moment.utc(date).format('YYYY-MM-DD HH:mm UTC')
     }
@@ -94,9 +91,24 @@ export default {
     }
   },
 
+  methods: {
+    dateToUnix(date) {
+      return (new Date(date).getTime() / 1000).toFixed(0)
+    }
+  },
+
   computed: {
-    ra_hours () {
-      // default is degrees, but we need hours
+    raHours () {
+      // current_image.right_ascension used hours until march 8, 2023, 9:20 UTC.
+      // this block checks for images taken before then, and doesn't do a decimal -> hours conversion.
+      // If we ever stop using images this old, this block can be removed.
+      const unixCaptureDate = this.dateToUnix(this.current_image.capture_date)
+      const whenWeSwitchedHoursToDegrees = 1678267200 // unix
+      if (unixCaptureDate < whenWeSwitchedHoursToDegrees) {
+        return this.current_image.right_ascension
+      }
+
+      // default is degrees, so convert to hours
       return this.current_image.right_ascension / 15
     }
   }

--- a/src/components/ImageDisplay/ImageInfoBar.vue
+++ b/src/components/ImageDisplay/ImageInfoBar.vue
@@ -92,7 +92,7 @@ export default {
   },
 
   methods: {
-    dateToUnix(date) {
+    dateToUnix (date) {
       return (new Date(date).getTime() / 1000).toFixed(0)
     }
   },

--- a/src/components/ImageDisplay/ImageInfoBar.vue
+++ b/src/components/ImageDisplay/ImageInfoBar.vue
@@ -15,7 +15,7 @@
       style="display:flex"
     >
       ra:&nbsp;<ra-display
-        :ra_hours_decimal="current_image.right_ascension"
+        :ra_hours_decimal="ra_hours"
         :decimal_precision="3"
       />
     </div>
@@ -91,6 +91,13 @@ export default {
         this.fwhm = Number(response.data.FWHMASEC).toFixed(2)
         this.sepsky = parseInt(response.data.SEPSKY)
       })
+    }
+  },
+
+  computed: {
+    ra_hours () {
+      // default is degrees, but we need hours
+      return this.current_image.right_ascension / 15
     }
   }
 


### PR DESCRIPTION
This update adjusts to a change in the way right ascension is retrieved from fits headers. Previously, image RA was sourced from the 'RAHRS' key, which was expressed in decimal hours. Now, the RA is sourced from the 'CRVAL1' key, with units of decimal degrees. 

The header keys don't matter in the frontend, but the units do. The solution here is a simple computed property that transforms the value from degrees to hours, so that it works as normal in the RaDisplay.vue component that expects input in hours. 

Note that this will break the ra display for any images taken before this change was implemented.