### PR TITLE
Remove the use of global_config[site].site as it is a redundant key

### DIFF
--- a/src/components/NavbarSiteDropdown.vue
+++ b/src/components/NavbarSiteDropdown.vue
@@ -17,7 +17,7 @@
           >
             <div :class="[site_online_class(site), 'status-dot']" />
             <div class="site-name-short">
-              {{ global_config[site].site }}&nbsp;
+              {{ site }}&nbsp;
             </div>
             <div class="site-name-expanded">
               {{ global_config[site].name }}
@@ -33,7 +33,7 @@
           >
             <div :class="[site_online_class(site), 'status-dot']" />
             <div class="site-name-short">
-              {{ global_config[site].site }}&nbsp;
+              {{ site }}&nbsp;
             </div>
             <div class="site-name-expanded">
               {{ global_config[site].name }}

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -56,8 +56,8 @@ const getters = {
     let sites = []
     Object.keys(state.global_config).forEach(site => {
       const s = {
+        site,
         name: state.global_config[site].name.toString(),
-        site: state.global_config[site].site.toString(),
         latitude: parseFloat(state.global_config[site].latitude),
         longitude: parseFloat(state.global_config[site].longitude),
         TZ_database_name: state.global_config[site].TZ_database_name


### PR DESCRIPTION
The global config is structured like 
```
global config = {
  mrc: {
    site: "mrc",
    ....
  },
  eco: {
    site: "eco",
    ...
  },
  ...
}
```

This "site" key is redundant, and should be phased out of the site config spec. This PR removes the frontend's dependency on this key, fixing a bug that was caused by a site missing the "site" key. 