### PR TITLE
Make sequencer script names more readable

### DIFF
--- a/src/store/modules/scriptSettings.js
+++ b/src/store/modules/scriptSettings.js
@@ -43,9 +43,9 @@ const state = {
 
   // This is used to populate the dropdown list where users select a script in the UI
   readableScriptNames: {
-    focusAuto: 'Focus Auto',
-    focusExtensive: 'Focus Extensive',
-    focusFine: 'Focus Fine',
+    focusAuto: 'Auto Focus',
+    focusExtensive: 'Extensive Focus',
+    focusFine: 'Fine Focus',
     restackLocalCalibrations: 'Restack Local Calibrations',
     collectBiasesAndDarks: 'Collect Biases and Darks',
     collectScreenFlats: 'Collect Screen Flats',


### PR DESCRIPTION
Simple change to the display name for sequencer scripts:
Focus Auto ==> Auto Focus
Focus Fine ==> Fine Focus
Focus Extensive ==> Extensive Focus

The payload for these scripts probably isn't worth changing, as it currently works and is easy to understand on both ends of the stack. The scripts still send under the name "focusAuto", etc. The only change here applies to the name displayed to the user. 