### PR TITLE
Add improvements to the projects table

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1426,7 +1426,10 @@ export default {
             type: 'is-success'
           })
           this.addProjectToCalendarEvents(project.project_name, project.created_at, this.project_events)
-          this.getUserProjects()
+
+          // refresh the projects table
+          this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+
           this.getUserEvents()
           this.clearProjectForm()
         }).catch(error => {
@@ -1486,7 +1489,10 @@ export default {
             message: 'Project has been modified.',
             type: 'is-success'
           })
-          this.getUserProjects()
+
+          // refresh the projects table
+          this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+
           this.getUserEvents()
         }).catch(error => {
           this.$buefy.toast.open({
@@ -1508,9 +1514,6 @@ export default {
       }).catch(error => {
         console.log(error)
       })
-    },
-    getUserProjects () {
-      this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
     },
     getUserEvents () {
       this.$store.dispatch('user_data/fetchUserEvents', this.user.sub)

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1311,9 +1311,12 @@ export default {
       } else {
         this.targets[target_index].ra = ''
         this.targets[target_index].dec = ''
-        this.$buefy.toast.open({
+        this.$buefy.notification.open({
+          duration: 10000,
           message: 'Could not resolve object with name ' + this.targets[target_index].name,
-          type: 'is-danger'
+          position: 'is-top',
+          type: 'is-danger',
+          hasIcon: true
         })
       }
     },
@@ -1344,6 +1347,13 @@ export default {
         this.$buefy.toast.open({
           message: "Please avoid '#' in the project name",
           type: 'is-danger'
+        })
+        this.$buefy.notification.open({
+          duration: 10000,
+          message: 'Please avoid \'#\' in the project name',
+          position: 'is-top',
+          type: 'is-danger',
+          hasIcon: true
         })
         // If user selects no sites, consider the selection to be the current site
         if (this.project_sites.length === 0) {
@@ -1522,12 +1532,24 @@ export default {
     // Function to get filters at any site to populate filter dropdown
     get_default_filter_options (site) {
       if (site == 'common pool') {
-        return
+        return []
       }
-      const site_cfg = this.global_config[site]
-      const default_filter_wheel_name = site_cfg.defaults.filter_wheel
-      const filter_wheel_options = site_cfg.filter_wheel[default_filter_wheel_name].settings.filter_data
-      return filter_wheel_options
+      try {
+        const site_cfg = this.global_config[site]
+        const default_filter_wheel_name = site_cfg.defaults?.filter_wheel
+        const filter_wheel_options = site_cfg.filter_wheel[default_filter_wheel_name].settings.filter_data
+        return filter_wheel_options
+      } catch (error) {
+        console.error('Error getting default filter wheels for site ', site)
+        this.$buefy.notification.open({
+          duration: 10000,
+          message: `Failed to fetch specific filters available for site <b>${site.toUpperCase()}</b>.`,
+          position: 'is-top',
+          type: 'is-danger',
+          hasIcon: true
+        })
+        return []
+      }
     }
   },
   computed: {
@@ -1541,7 +1563,7 @@ export default {
       const selected_sites = this.project_sites.flat(Infinity)
 
       if (selected_sites.length != 0) {
-        let fwo = []
+        let fwo = [] // fwo stands for filter wheel options
         for (const site of selected_sites) {
           if (site != 'common pool') {
             const filter_list = this.get_default_filter_options(site).map(x => x[0])

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -18,6 +18,8 @@
       :focusable="isFocusable"
       :paginated="true"
       :per-page="20"
+      default-sort="created_at"
+      default-sort-direction="desc"
       detailed
       class="my-table no-margin"
     >
@@ -27,6 +29,15 @@
         label="project name"
       >
         {{ props.row.project_name }}
+      </b-table-column>
+
+      <b-table-column
+        v-slot="props"
+        field="created_at"
+        label="created"
+        sortable
+      >
+        {{ formatCreatedAtDate(props.row.created_at) }}
       </b-table-column>
 
       <b-table-column
@@ -161,6 +172,15 @@ export default {
 
   },
   methods: {
+    formatCreatedAtDate (utcTimestamp) {
+      const date = new Date(utcTimestamp)
+      const formattedDate = date.toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: '2-digit',
+        year: '2-digit'
+      }).replace(/\//g, '/')
+      return formattedDate
+    },
     displayEventDuration (event) {
       const start = moment(event.start)
       const end = moment(event.end)

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -97,7 +97,7 @@
         <button
           class="button is-text"
           :class="{'is-loading': projectsIsLoading}"
-          @click="$store.dispatch('user_data/fetchUserProjects', user.sub)"
+          @click="$store.dispatch('user_data/refreshProjectsTableData', user.sub)"
         >
           <span class="icon is-large has-text-grey-lighter">
             <i class="mdi mdi-refresh mdi-24px" />

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -13,7 +13,7 @@
     </div>
     <b-table
       :data="projectsToDisplay"
-      :loading="user_projects_is_loading"
+      :loading="projectsIsLoading"
       :empty="user_projects=={}"
       :focusable="isFocusable"
       :paginated="true"
@@ -131,9 +131,6 @@ export default {
   data () {
     return {
 
-      // Admins can choose to see all ptr projects, not just their own.
-      show_everyones_projects: false,
-
       localTime: '-',
       siteTime: '-',
       utcTime: '-',
@@ -148,22 +145,18 @@ export default {
     }
   },
   created () {
-    this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
+    this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
   },
   destroyed () {
   },
   watch: {
 
     user () {
-      this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
+      this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
     },
 
-    show_everyones_projects (show_all_projects) {
-      if (show_all_projects) {
-        this.$store.dispatch('user_data/fetchAllProjects')
-      } else {
-        this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
-      }
+    show_everyones_projects () {
+      this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
     }
 
   },
@@ -229,6 +222,10 @@ export default {
       'all_projects',
       'all_projects_is_loading'
     ]),
+    show_everyones_projects: {
+      get () { return this.$store.state.user_data.show_everyones_projects },
+      set (val) { console.log(this.show_everyones_projects); this.$store.commit('user_data/show_everyones_projects', val) }
+    },
     projectsToDisplay () {
       return this.show_everyones_projects
         ? this.all_projects


### PR DESCRIPTION
Various improvements:
- added some improvements to the projects table UX, which makes it more clear to the user when operations are in progress. 
  - Deleting a project used to include a lag between the click and any indicator that something is happening but now it immediately starts a reload of the table with a spinner that ends with a fresh, updated table when the delete operation has finished. 
  - There are also a few other events in other parts of the app that trigger a table refresh (e.g. changing the logged in user, creating a new project, etc) and these should also prompt a more obvious refresh of the projects table, assuming it is visible. 
- the projects table includes the created date now, and is sorted by default with the newest projects first.
- Fixed a bug that prevented the 'clone' or 'modify' buttons to work. This happened specifically on projects that were associated with sites missing a filter wheel in the config (e.g. ECO or MRC, which are different now that we separate the configs for sites and observing platforms).