### PR TITLE
Reintroduce camera areas field

### DIFF
--- a/src/components/FormElements/CommandButton.vue
+++ b/src/components/FormElements/CommandButton.vue
@@ -1,8 +1,10 @@
 <template>
   <button
     class="button"
-    :class="{ 'is-loading': isLoading, 'is-admin': admin }"
+    :class="{ 'is-loading': isLoading, 'is-admin': admin, 'is-preview-mode': previewMode }"
     :disabled="isDisabled"
+    @mouseover="isHovering = true"
+    @mouseleave="isHovering = false"
     @click="handleClick"
   >
     <slot> {{ data.button_name }} </slot>
@@ -28,12 +30,20 @@ export default {
   mixins: [commands_mixin],
   data () {
     return {
-      isLoading: false
+      isLoading: false,
+      shiftKeyActive: false,
+      isHovering: false
     }
   },
   methods: {
 
     async handleClick () {
+      // Use the value of preview mode when the button was first clicked
+      // Preview mode doesn't send the command to the backend, but simply
+      // displays the payload to the user.
+      const inPreviewMode = this.previewMode
+
+      // Add a loading spinner to the button
       this.isLoading = true
 
       if (this.data.site == '' || this.data.mount == '') {
@@ -49,23 +59,69 @@ export default {
         timestamp: parseInt(Date.now() / 1000)
       }
 
-      const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.data.site}`
-      const options = await this.getAuthHeader()
-      axios.post(url, commandPayload, options).then(response => {
+      if (inPreviewMode) {
         this.isLoading = false
-        console.log('command response: ', response.data)
-        this.$emit('jobPost', response.data)
-      }).catch(error => {
-        this.isLoading = false
-        console.log(error)
-        this.handleNotAuthorizedResponse(error)
-      })
+        const commandPayloadString = JSON.stringify(commandPayload, null, 4)
+        const message = `
+          <b>Command Payload - Preview Mode</b>
+          <p> Note: commands are not sent in preview mode. </p>
+          <hr>
+          <div style="white-space: pre;">${commandPayloadString}</div>`
+        this.$buefy.notification.open({
+          message,
+          position: 'is-bottom',
+          type: 'is-warning',
+          hasIcon: true,
+          indefinite: true
+
+        })
+      } else {
+        const url = `${this.$store.state.api_endpoints.jobs_api}/newjob?site=${this.data.site}`
+        const options = await this.getAuthHeader()
+        axios.post(url, commandPayload, options).then(response => {
+          this.isLoading = false
+          console.log('command response: ', response.data)
+          this.$emit('jobPost', response.data)
+        }).catch(error => {
+          this.isLoading = false
+          console.log(error)
+          this.handleNotAuthorizedResponse(error)
+        })
+      }
+    },
+
+    onKeydown (event) {
+      if (event.shiftKey) {
+        this.shiftKeyActive = true
+      }
+    },
+
+    onKeyup (event) {
+      if (!event.shiftKe) {
+        this.shiftKeyActive = false
+      }
     }
+  },
+  mounted () {
+    window.addEventListener('keydown', this.onKeydown)
+    window.addEventListener('keyup', this.onKeyup)
+  },
+  beforeDestroy () {
+    window.removeEventListener('keydown', this.onKeydown)
+    window.removeEventListener('keyup', this.onKeyup)
   },
   computed: {
     ...mapGetters('auth', {
       token: 'getToken'
-    })
+    }),
+
+    // Preview mode is enabled when a user holds the shift key while clicking.
+    // It changes the command button style and results in a preview
+    // of the command payload being displayed. The command is not
+    // sent to the backend.
+    previewMode () {
+      return this.shiftKeyActive && this.isHovering
+    }
   }
 }
 </script>
@@ -75,5 +131,12 @@ export default {
 .is-admin {
     background-color: rgba(68, 0, 255, 0.164);
     border-color: rgba(76, 0, 255, 0.541);
+}
+.is-preview-mode {
+  /* border-width: 2px; */
+  color: gold !important;
+  background-color: rgba(199, 172, 47, 0.164) !important;
+  border-color: gold !important;
+  border-style: dashed;
 }
 </style>

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -137,7 +137,6 @@
 
     <!-- Hide this field until we need it (requested march 2023) -->
     <b-field
-      v-show="false"
       v-if="camera_areas && camera_areas.length != 0"
       horizontal
       label="Area"
@@ -310,6 +309,12 @@ export default {
     SimpleDeviceStatus,
     CameraBinSelectField
   },
+  mounted () {
+    // set the initial value for camera areas based on the options specified in the config
+    if (this.camera_areas.length) {
+      this.camera_areas_selection = this.camera_areas[0]
+    }
+  },
   data () {
     return {
       isExpandedStatusVisible: false
@@ -321,6 +326,7 @@ export default {
     camera_areas_selection () {
       this.subframe_is_active = false
     }
+
   },
 
   computed: {

--- a/src/components/InstrumentControls/Sequencer.vue
+++ b/src/components/InstrumentControls/Sequencer.vue
@@ -158,7 +158,6 @@ export default {
           name: scripts[key]
         })
       })
-      console.log(options)
       return options
     },
     sitecode () {


### PR DESCRIPTION
Reintroduced the field for selecting camera areas in the camera control tab.

Also added debugging functionality to command buttons: holding shift while hovering the mouse over a command button will turn it yellow to signify preview mode, and clicking while holding shift will run the command in preview mode:
- nothing is sent to the backend
- the payload of the command that would normally be sent is displayed in a notification box

This is useful for testing changes to commands without worrying about messing with any real observing routines. 