### PR TITLE
Add buttons to quickly switch between sites

### DIFF
--- a/src/components/ImageDisplay/ImageInfoBar.vue
+++ b/src/components/ImageDisplay/ImageInfoBar.vue
@@ -32,7 +32,7 @@
       airmass:&nbsp;{{ current_image.airmass }}
     </div>
     <div class="image-info-bar-item altitude">
-      altitude:&nbsp;{{ current_image.altitude }}°
+      altitude:&nbsp;{{ truncateDecimalString(current_image.altitude, 4) }}°
     </div>
     <div class="image-info-bar-item obstime">
       {{ current_image.capture_date | dateToReadable }}
@@ -98,6 +98,12 @@ export default {
   methods: {
     dateToUnix (date) {
       return (new Date(date).getTime() / 1000).toFixed(0)
+    },
+    truncateDecimalString (decimalString, n) {
+      const number = parseFloat(decimalString)
+      const factor = Math.pow(10, n)
+      const truncatedNumber = Math.floor(number * factor) / factor
+      return truncatedNumber.toString()
     }
   },
 

--- a/src/components/QuickSiteSwitchButtons.vue
+++ b/src/components/QuickSiteSwitchButtons.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="site-switch-buttons">
+    <b-button
+      v-for="site in available_sites"
+      :key="site"
+      size="is-small"
+      :class="{ 'active-site': site == currentSite}"
+      @click="goToDifferentSite(site)"
+    >
+      {{ site }}
+    </b-button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'QuickSiteSwitchButtons',
+  props: {
+    currentSite: String
+  },
+  computed: {
+    available_sites () {
+      return [
+        ...this.$store.getters['site_config/all_sites_real'].map(s => s.site),
+        ...this.$store.getters['site_config/all_sites_simulated'].map(s => s.site)
+      ]
+    }
+  },
+  methods: {
+    goToDifferentSite (destinationSite) {
+      // Do nothing if navigating to the current page
+      if (destinationSite == this.currentSite) {
+        return
+      }
+      // Create a copy of the current route params
+      const newParams = { ...this.$route.params }
+
+      // Update the desired parameter value
+      newParams.sitecode = destinationSite
+
+      // Navigate to the new route using the updated route params
+      this.$router.push({ name: this.$route.name, params: newParams })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.site-switch-buttons {
+  padding-top: 15px;
+  display:flex;
+  flex-direction:column;
+}
+.active-site {
+  font-weight: bold;
+  border-right-color: #eee;
+  border-right-width: 5px;
+  border-top-right-radius: 0px !important;
+  border-bottom-right-radius: 0px !important;
+}
+</style>

--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -53,6 +53,7 @@
     </div>
 
     <div class="page-view">
+      <QuickSiteSwitchButtons :current-site="sitecode" />
       <component
         :is="`site-${subpage}`"
         :sitecode="sitecode"
@@ -78,6 +79,7 @@ import StatusPanelCollapsible from '@/components/status/StatusPanelCollapsible'
 import SiteStatusFooter from '@/components/status/SiteStatusFooter'
 import SiteStatusFooterMobile from '@/components/status/SiteStatusFooterMobile'
 import SiteNavbar from '@/components/SiteNavbar.vue'
+import QuickSiteSwitchButtons from '@/components/QuickSiteSwitchButtons.vue'
 
 import SiteHome from '@/components/sitepages/SiteHome'
 import SiteObserve from '@/components/sitepages/SiteObserve'
@@ -103,7 +105,8 @@ export default {
     StatusPanelCollapsible,
     SiteStatusFooter,
     SiteStatusFooterMobile,
-    SiteNavbar
+    SiteNavbar,
+    QuickSiteSwitchButtons
   },
   props: {
     sitecode: {
@@ -214,6 +217,8 @@ export default {
 .page-view {
   grid-row: 2;
   overflow-y: auto;
+  display:flex;
+  padding-top: 1em;
 }
 .status-footer {
   grid-row: 3;
@@ -234,10 +239,6 @@ export default {
   }
 }
 
-.main-page-content {
-  width: 100%;
-}
-
 .menu-column {
   height: auto;
   padding: 0 auto;
@@ -253,7 +254,8 @@ export default {
   bottom: 300px;
   z-index: 0;
   display:flex;
-  margin-bottom: 1em;
+  margin-bottom: -6px;
+  //margin-bottom: 1em;
 }
 .mobile-site-menu a {
   width: 100%;


### PR DESCRIPTION
Added buttons on the left side of the screen to quickly switch between sites while staying on the same page (e.g. changing from the mrc1 calendar to the aro1 calendar). 

This is a quick and unpolished addition; changes in the config handling will require slight modifications to the sites displayed here, but it's good enough for now. 