### PR TITLE
Add ui sync prototype

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 [*.{js,jsx,ts,tsx,vue}]
 indent_style = space
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,8 @@ module.exports = {
     'vue/require-prop-types': 'off',
     'vue/order-in-components': 'off',
     'vue/multi-word-component-names': 'off',
+    'vue/no-v-for-template-key': 'off',
+    'vue/no-v-for-template-key-on-child': 'off',
 
     /* Don't automatically fix these when running `eslint --fix`, but keep the warning/error */
 

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,11 @@
     integrity="sha512-57oZ/vW8ANMjR/KQ6Be9v/+/h6bq9/l3f0Oc7vn6qMqyhvPd1cvKBRWWpzu0QoneImqr2SkmO4MSqU+RpHom3Q=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
+  <!-- SocketIO -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.6.2/socket.io.js"
+    integrity="sha512-jMNwWSmjje4fjYut9MBGKXw5FZA6D67NHAuC9szpjbbjg51KefquNfvn4DalCbGfkcv/jHsHnPo1o47+8u4biA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
   <!-- Map scripts -->
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBoMXHSu68h9ET9Rh8UPMlTKjQ1J4MNHFQ"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/OverlappingMarkerSpiderfier/1.0.3/oms.min.js"></script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <template>
   <div id="app">
     <router-view class="router-view" />
-
   </div>
 </template>
 

--- a/src/components/CommandTabsAccordion.vue
+++ b/src/components/CommandTabsAccordion.vue
@@ -1,6 +1,7 @@
 
 <template>
   <div class="command-tab-accordion-wrapper">
+    <UiSyncControls />
     <b-collapse
       v-for="(instrument, index) of instruments"
       :key="index"
@@ -44,6 +45,7 @@ import {
   Enclosure, Screen, Telescope, Rotator, Focuser, InstrumentSelector,
   Camera, Sequencer, Settings
 } from '@/components/InstrumentControls'
+import UiSyncControls from '@/components/UiSyncControls'
 
 export default {
   name: 'CommandTabAccordion',
@@ -56,7 +58,8 @@ export default {
     InstrumentSelector,
     Camera,
     Sequencer,
-    Settings
+    Settings,
+    UiSyncControls
   },
   props: {
     controls: {

--- a/src/components/CommandTabsWide.vue
+++ b/src/components/CommandTabsWide.vue
@@ -16,7 +16,7 @@
           :value="index.toString()"
           :title="instrument"
         >
-          <UiSyncControls />
+          <UiSyncControls class="ui-sync-controls"/>
           <component
             :is="instrument"
             class="accordion-content"
@@ -140,6 +140,10 @@ $accordion-header-background: $grey-darker;
     font-variant: small-caps;
     color: $grey-lighter;
   }
+}
+
+.ui-sync-controls {
+  padding: 5px;
 }
 
 .accordion-header {

--- a/src/components/CommandTabsWide.vue
+++ b/src/components/CommandTabsWide.vue
@@ -5,9 +5,9 @@
       type="is-toggle"
       size="is-small"
       :animated="false"
-      :initial_tab_index="active_controls_tab"
+      :tab_index="active_controls_tab"
       multiline
-      @selected-index="active_controls_tab =$event"
+      @selected-index="active_controls_tab=$event"
     >
       <template v-for="(instrument, index) of instruments">
         <TabItem
@@ -16,13 +16,7 @@
           :value="index.toString()"
           :title="instrument"
         >
-          <!--div class="accordion-header">
-            <div class="instrument-type-label" >
-              {{instrument}}
-            </div>
-            <div style="flex-grow: 1;"/>
-            <div class="instrument-instance-label">{{selected_instrument(instrument)}}</div>
-          </div-->
+          <UiSyncControls />
           <component
             :is="instrument"
             class="accordion-content"
@@ -45,6 +39,7 @@ import {
 } from '@/components/InstrumentControls'
 import Tabs from '@/components/Tabs'
 import TabItem from '@/components/TabItem'
+import UiSyncControls from '@/components/UiSyncControls'
 
 export default {
   name: 'CommandTabsWide',
@@ -60,7 +55,8 @@ export default {
     Sequencer,
     Settings,
     Tabs,
-    TabItem
+    TabItem,
+    UiSyncControls
   },
 
   methods: {
@@ -75,10 +71,11 @@ export default {
   },
 
   computed: {
+
+    // controls tab set to camera by default in user_interface
     active_controls_tab: {
       get () { return this.$store.state.user_interface.selected_controls_tab },
-      set (value) { this.$store.commit('user_interface/setActiveControlsTab', value) }
-      // controls tab set to camera by default in user_interface
+      set (value) { this.$store.commit('user_interface/selected_controls_tab', value) }
     },
 
     ...mapState('site_config', [

--- a/src/components/InstrumentControls/InstrumentSelector.vue
+++ b/src/components/InstrumentControls/InstrumentSelector.vue
@@ -88,54 +88,9 @@ export default {
         this.$store.commit('command_params/selector_position', val)
       }
     },
-
-    subframeIsActive: {
-      get () { return this.$store.getters['command_params/subframeIsActive'] },
-      set (val) { this.$store.commit('command_params/subframeIsActive', val) }
-    },
-    camera_areas_selection: {
-      get () { return this.$store.getters['command_params/camera_areas_selection'] },
-      set (val) { this.$store.commit('command_params/camera_areas_selection', val) }
-    },
-    camera_note: {
-      get () { return this.$store.getters['command_params/camera_note'] },
-      set (val) { this.$store.commit('command_params/camera_note', val) }
-    },
-    camera_exposure: {
-      get () { return this.$store.getters['command_params/camera_exposure'] },
-      set (val) { this.$store.commit('command_params/camera_exposure', val) }
-    },
-    camera_count: {
-      get () { return this.$store.getters['command_params/camera_count'] },
-      set (val) { this.$store.commit('command_params/camera_count', val) }
-    },
-    camera_bin: {
-      get () { return this.$store.getters['command_params/camera_bin'] },
-      set (val) { this.$store.commit('command_params/camera_bin', val) }
-    },
-    camera_dither: {
-      get () { return this.$store.getters['command_params/camera_dither'] },
-      set (val) { this.$store.commit('command_params/camera_dither', val) }
-    },
-    camera_extract: {
-      get () { return this.$store.getters['command_params/camera_extract'] },
-      set (val) { this.$store.commit('command_params/camera_extract', val) }
-    },
-    camera_image_type: {
-      get () { return this.$store.getters['command_params/camera_image_type'] },
-      set (val) { this.$store.commit('command_params/camera_image_type', val) }
-    },
-    filter_wheel_options_selection: {
-      get () { return this.$store.getters['command_params/filter_wheel_options_selection'] },
-      set (val) { this.$store.commit('command_params/filter_wheel_options_selection', val) }
-    }
   },
 
   watch: {
-    // If the user changes the chip area parameter, deactivate the subframe.
-    camera_areas_selection () {
-      this.subframeIsActive = false
-    },
 
     // When switching sites, make the instrument selector select field value be the active one.
     sitecode () {

--- a/src/components/NavbarSitePreview.vue
+++ b/src/components/NavbarSitePreview.vue
@@ -82,7 +82,7 @@ export default {
   computed: {
     active_subpage: {
       get () { return this.$store.state.user_interface.selected_subpage },
-      set (value) { this.$store.commit('user_interface/setActiveSubpage', value) }
+      set (value) { this.$store.commit('user_interface/selected_subpage', value) }
     }
   },
 

--- a/src/components/SiteNavbar.vue
+++ b/src/components/SiteNavbar.vue
@@ -63,19 +63,19 @@
     <template slot="end">
       <b-navbar-item tag="div">
         <div
-          v-if="$auth.isAuthenticated"
+          v-if="userIsAuthenticated"
           class="navbar-item has-dropdown is-hoverable is-dark"
         >
           <div class="navbar-link">
             <img
-              :src="$auth.user.picture"
+              :src="profileUrl"
               width="25"
               height="25"
               style="border-radius: 50%;"
               referrerpolicy="no-referrer"
             >
             <div style="width:5px" />
-            <p> {{ $auth.user.name }} </p>
+            <p> {{ userName }} </p>
           </div>
 
           <div class="navbar-dropdown">
@@ -117,7 +117,7 @@
             </b-button>
           </b-tooltip>
           <b-button
-            v-if="!$auth.isAuthenticated"
+            v-if="!userIsAuthenticated"
             class="button"
             @click="login"
           >
@@ -155,6 +155,12 @@ export default {
     ...mapState('sitestatus', ['site_open_status', 'stale_age_ms']),
     ...mapState('site_config', [
       'selected_site'
+    ]),
+    ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
+      'profileUrl'
     ]),
 
     real_sites () {

--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -15,15 +15,6 @@
         {{ tab.title }}
       </li>
     </ul>
-    <!--div class="testgrid">
-        <div class="testitem">one</div>
-        <div class="testitem">two</div>
-        <div class="testitem">a long word</div>
-        <div class="testitem">four</div>
-        <div class="testitem">five</div>
-        <div class="testitem">six</div>
-        <div class="testitem">seven</div>
-    </div-->
     <slot />
   </div>
 </template>
@@ -44,7 +35,7 @@ export default {
     }
   },
   props: {
-    initial_tab_index: {
+    tab_index: {
       type: Number,
       default: 0
     }
@@ -56,7 +47,7 @@ export default {
   },
   mounted () {
     // this.set_lengths()
-    this.select_tab(this.initial_tab_index)
+    this.select_tab(this.tab_index)
   },
   methods: {
     select_tab (clicked_tab_index) {
@@ -81,6 +72,9 @@ export default {
     }
   },
   watch: {
+    tab_index () {
+      this.select_tab(this.tab_index)
+    },
     tabs () {
       this.set_lengths()
     }

--- a/src/components/UiSyncControls.vue
+++ b/src/components/UiSyncControls.vue
@@ -1,50 +1,61 @@
 <template>
-  <div
-    class="ui-sync-buttons"
-    style="display: flex; gap: 1em; padding: 10px; border-bottom: grey 1px solid;"
-  >
-    <b-field>
-      <b-tooltip
-        :active="!userIsAuthenticated || currentLeaderExists"
-        :delay="500"
-        type="is-warning"
-        position="is-top"
-      >
+  <div class="wrapper">
+    <div class="ui-sync-buttons">
+      <b-field style="margin: 0;">
+        <b-tooltip
+          :active="!userIsAuthenticated || currentLeaderExists"
+          :delay="500"
+          type="is-warning"
+          position="is-top"
+        >
+          <b-radio-button
+            v-model="uiSyncRole"
+            :disabled="!userIsAuthenticated || currentLeaderExists"
+            native-value="leader"
+            type="is-warning is-light"
+          >
+            <span>Leader</span>
+          </b-radio-button>
+          <template
+            v-if="currentLeaderExists"
+            #content
+          >
+            You cannot lead because someone is currently a leader already
+          </template>
+          <template
+            v-else-if="!userIsAuthenticated"
+            #content
+          >
+            You need to be logged in to be a leader
+          </template>
+        </b-tooltip>
+
         <b-radio-button
           v-model="uiSyncRole"
-          :disabled="!userIsAuthenticated || currentLeaderExists"
-          native-value="leader"
+          native-value="follower"
           type="is-warning is-light"
         >
-          <span>Leader</span>
+          <span>Follower</span>
         </b-radio-button>
-        <template v-if="currentLeaderExists" #content>
-          You cannot lead because someone is currently a leader already
-        </template>
-        <template v-else-if="!userIsAuthenticated" #content>
-          You need to be logged in to be a leader
-        </template>
-      </b-tooltip>
 
-      <b-radio-button
-        v-model="uiSyncRole"
-        native-value="follower"
-        type="is-warning is-light"
+        <b-radio-button
+          v-model="uiSyncRole"
+          native-value="none"
+          type="is-warning is-light"
+        >
+          None
+        </b-radio-button>
+      </b-field>
+      <button
+        class="help-button"
+        @click="showHelp"
       >
-        <span>Follower</span>
-      </b-radio-button>
-
-      <b-radio-button
-        v-model="uiSyncRole"
-        native-value="none"
-        type="is-warning is-light"
-      >
-        None
-      </b-radio-button>
-    </b-field>
+        <i class="fas fa-question" />
+      </button>
+    </div>
     <div class="leader-info">
       <span>current leader: </span>
-      <span>{{ currentLeader }}</span>
+      <b>{{ currentLeader }}</b>
     </div>
   </div>
 </template>
@@ -60,16 +71,100 @@ export default {
       set (val) { return this.$store.commit('uiSync/ui_sync_role', val) }
     },
     currentLeaderExists () {
-      return this.currentLeader != '-'
+      return this.uiSyncRole != 'leader' && this.currentLeader != '-'
     },
     currentLeader () {
-      return this.$store.getters['uiSync/currentLeader']
+      if (this.uiSyncRole == 'leader') {
+        return this.userName
+      } else {
+        return this.$store.getters['uiSync/currentLeader']
+      }
     }
+  },
+  methods: {
+    showHelp () {
+      this.$buefy.dialog.alert({
+        title: 'UI Sync',
+        //hasIcon: true,
+        type: 'is-info',
+        message: `
+                  <p>
+                  UI Sync is a way for you to see what other people are doing in the observatory.
+                  There are two roles: leader and follower.
+                  </p><br>
 
+                  <p>
+                  Anytime a leader makes changes in the control fields (e.g. change the exposure time),
+                  the value is propegated to all followers to see. 
+                  </p><br>
+
+                  <p>
+                  The command tab that the leader is currently viewing is also synchronized, so followers
+                  don't miss changes that might be hidden in another tab (e.g. if the leader goes to the 
+                  telescope tab to modify the pointing, all followers will be taken to the telescope
+                  as well).
+                  </p><br>
+
+                  <p>
+                  Followers can modify values in their UI, but these changes don't affect anyone else. 
+                  If you are a follower, be careful about making changes, since you now have to manually 
+                  keep track of which changes are yours and which are from the leader. If the leader 
+                  changes a field that a follower modified, the followers change will be overwritten.
+                  </p><br>
+
+                  <p>
+                  If you want to resync your state with the leader, simply set your role to 'none' and then
+                  back to 'follower' again. 
+                  </p><br>
+
+                  <p>
+                  Switching sites will automatically end your role as leader or follower. 
+                  </p><br>
+
+                  <p>
+                  There may only be one leader at a time. Please remember to end your leader session when 
+                  you are finished. 
+                  </p><br>
+                  `,
+        confirmText: 'close',
+        canCancel: ['escape', 'outside'],
+      })
+    }
   }
 }
 </script>
 
 <style lang="scss" scoped>
+.wrapper {
+  margin-bottom: 1em;
+}
+.ui-sync-buttons {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+  //padding: 10px;
+}
+.leader-info {
+  padding: 5px;
+}
+.help-button {
+    background-color: #333;
+    border: none;
+    color: white;
+    padding: 4px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 8px;
+    transition-duration: 0.4s;
+    cursor: pointer;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+}
 
+.help-button:hover {
+    background-color: #555;
+    color: white;
+}
 </style>

--- a/src/components/UiSyncControls.vue
+++ b/src/components/UiSyncControls.vue
@@ -1,0 +1,75 @@
+<template>
+  <div
+    class="ui-sync-buttons"
+    style="display: flex; gap: 1em; padding: 10px; border-bottom: grey 1px solid;"
+  >
+    <b-field>
+      <b-tooltip
+        :active="!userIsAuthenticated || currentLeaderExists"
+        :delay="500"
+        type="is-warning"
+        position="is-top"
+      >
+        <b-radio-button
+          v-model="uiSyncRole"
+          :disabled="!userIsAuthenticated || currentLeaderExists"
+          native-value="leader"
+          type="is-warning is-light"
+        >
+          <span>Leader</span>
+        </b-radio-button>
+        <template v-if="currentLeaderExists" #content>
+          You cannot lead because someone is currently a leader already
+        </template>
+        <template v-else-if="!userIsAuthenticated" #content>
+          You need to be logged in to be a leader
+        </template>
+      </b-tooltip>
+
+      <b-radio-button
+        v-model="uiSyncRole"
+        native-value="follower"
+        type="is-warning is-light"
+      >
+        <span>Follower</span>
+      </b-radio-button>
+
+      <b-radio-button
+        v-model="uiSyncRole"
+        native-value="none"
+        type="is-warning is-light"
+      >
+        None
+      </b-radio-button>
+    </b-field>
+    <div class="leader-info">
+      <span>current leader: </span>
+      <span>{{ currentLeader }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { user_mixin } from '@/mixins/user_mixin'
+export default {
+  name: 'UiSyncControls',
+  mixins: [user_mixin],
+  computed: {
+    uiSyncRole: {
+      get () { return this.$store.state.uiSync.ui_sync_role },
+      set (val) { return this.$store.commit('uiSync/ui_sync_role', val) }
+    },
+    currentLeaderExists () {
+      return this.currentLeader != '-'
+    },
+    currentLeader () {
+      return this.$store.getters['uiSync/currentLeader']
+    }
+
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/src/components/calendar/UserEventsTable.vue
+++ b/src/components/calendar/UserEventsTable.vue
@@ -168,25 +168,15 @@ export default {
   },
   created () {
     window.moment = moment // use moment lib in browser devtools
-
-    // Only do this if the active user is authenticated and loaded.
-    if (this.user.sub) {
-      this.$store.dispatch('user_data/fetchUserEvents', this.user.sub)
-      this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
-    }
-  },
-  destroyed () {
   },
   watch: {
-
-    user () {
+    userId () {
       // Only do this if the active user is authenticated and loaded.
-      if (this.user.sub) {
-        this.$store.dispatch('user_data/fetchUserEvents', this.user.sub)
-        this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
+      if (this.userIsAuthenticated) {
+        this.$store.dispatch('user_data/fetchUserEvents', this.userId)
+        this.$store.dispatch('user_data/fetchUserProjects', this.userId)
       }
     }
-
   },
   methods: {
     setActiveEvent (row) {
@@ -226,6 +216,9 @@ export default {
   },
   computed: {
     ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
       'user_events',
       'user_events_is_loading',
       'user_projects',

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1400,7 +1400,7 @@ export default {
       const project = {
         project_name: this.project_name,
         created_at: moment().utc().format(),
-        user_id: this.user.sub,
+        user_id: this.userId,
         project_note: this.project_note,
         project_constraints: this.project_constraints,
         // List of objects (targets in the project)
@@ -1438,7 +1438,7 @@ export default {
           this.addProjectToCalendarEvents(project.project_name, project.created_at, this.project_events)
 
           // refresh the projects table
-          this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+          this.$store.dispatch('user_data/refreshProjectsTableData', this.userId)
 
           this.getUserEvents()
           this.clearProjectForm()
@@ -1459,7 +1459,7 @@ export default {
       const project = {
         project_name: this.project_name,
         created_at: moment().utc().format(),
-        user_id: this.user.sub,
+        user_id: this.userId,
         project_note: this.project_note,
         project_constraints: this.project_constraints,
         // List of objects (targets in the project)
@@ -1501,7 +1501,7 @@ export default {
           })
 
           // refresh the projects table
-          this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+          this.$store.dispatch('user_data/refreshProjectsTableData', this.userId)
 
           this.getUserEvents()
         }).catch(error => {
@@ -1526,7 +1526,7 @@ export default {
       })
     },
     getUserEvents () {
-      this.$store.dispatch('user_data/fetchUserEvents', this.user.sub)
+      this.$store.dispatch('user_data/fetchUserEvents', this.userId)
     },
 
     // Function to get filters at any site to populate filter dropdown
@@ -1603,6 +1603,9 @@ export default {
       'filter_wheel_options'
     ]),
     ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
       'user_events',
       'user_projects'
     ]),
@@ -1622,9 +1625,6 @@ export default {
     user_events_without_projects () {
       return this.user_events
         .filter(event => event.project_id != 'none')
-    },
-    user () {
-      return this.$auth.user
     }
   }
 }

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -155,19 +155,16 @@ export default {
 
     }
   },
-  created () {
-    this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
-  },
-  destroyed () {
-  },
   watch: {
-
-    user () {
-      this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+    userId () {
+      // Only do this if the active user is authenticated and loaded.
+      if (this.userIsAuthenticated) {
+        this.$store.dispatch('user_data/refreshProjectsTableData', this.userId)
+      }
     },
 
     show_everyones_projects () {
-      this.$store.dispatch('user_data/refreshProjectsTableData', this.user.sub)
+      this.$store.dispatch('user_data/refreshProjectsTableData', this.userId)
     }
 
   },
@@ -235,6 +232,9 @@ export default {
   },
   computed: {
     ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
       'user_events',
       'user_events_is_loading',
       'user_projects',

--- a/src/components/sitepages/SiteCalendar.vue
+++ b/src/components/sitepages/SiteCalendar.vue
@@ -39,7 +39,7 @@
 <script>
 import TheCalendar from '@/components/calendar/TheCalendar'
 import SiteReservationStatus from '@/components/calendar/SiteReservationStatus'
-import { mapGetters } from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import moment from 'moment'
 
 export default {
@@ -64,8 +64,8 @@ export default {
   },
   mounted () {
     // Load the users projects so they can add them to calendar events.
-    if (this.$auth.isAuthenticated) {
-      this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
+    if (this.userIsAuthenticated) {
+      this.$store.dispatch('user_data/fetchUserProjects', this.userId)
     }
   },
   destroyed () {
@@ -73,8 +73,8 @@ export default {
   },
   watch: {
     // Update the user's schedulable projects if the user changes.
-    user () {
-      this.$store.dispatch('user_data/fetchUserProjects', this.user.sub)
+    userId () {
+      this.$store.dispatch('user_data/fetchUserProjects', this.userId)
     }
   },
   methods: {
@@ -98,16 +98,12 @@ export default {
       'all_sites',
       'timezone'
     ]),
-
-    user () {
-      return this.$auth.user
-    },
-    username () {
-      if (this.$auth.isAuthenticated) {
-        return this.$auth.user.name
-      }
-      return '-'
-    },
+    ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
+      'userName'
+    ]),
 
     // Calendar Resources (Observatories) to feed into the calendar component
     listOfObservatories () {

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -303,7 +303,7 @@ export default {
 
     active_image_tools_tab: {
       get () { return this.$store.state.user_interface.selected_image_tools_tab },
-      set (value) { this.$store.commit('user_interface/setActiveImageToolsTab', value) }
+      set (value) { this.$store.commit('user_interface/selected_image_tools_tab', value) }
       // image tools tab set to analysis by default in user_interface
     },
 

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -1032,7 +1032,7 @@ export default {
 
     active_target_tab: {
       get () { return this.$store.state.user_interface.selected_target_tab },
-      set (value) { this.$store.commit('user_interface/setActiveTargetTab', value) }
+      set (value) { this.$store.commit('user_interface/selected_target_tab', value) }
       // targets sidebar tab set to telescope controls by default in user_interface
     },
 

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,10 @@ import JsonViewer from 'vue-json-viewer'
 
 // Import the Auth0 configuration and plugin
 import { domain, clientId, audience } from '../auth_config.json'
-import { Auth0Plugin } from './auth'
+import { Auth0Plugin, getInstance } from './auth'
+
+// Hide the 'you are running in development mode!' warning in the console.
+Vue.config.productionTip = false
 
 Vue.use(JsonViewer)
 Vue.use(LoadScript)
@@ -31,18 +34,32 @@ Vue.use(Auth0Plugin, {
   }
 })
 
-// Hide the 'you are running in development mode!' warning in the console.
-Vue.config.productionTip = false
+async function initAuth () {
+  const authService = getInstance()
+  if (authService.loading) {
+    await new Promise(resolve => {
+      authService.$watch('loading', loading => {
+        if (loading === false) {
+          resolve()
+        }
+      })
+    })
+  }
+  if (authService.isAuthenticated) {
+    store.dispatch('user_data/newUserLogin', authService.user)
+  }
+}
 
 // Load the config for all sites
 store.dispatch('site_config/update_config').then(() => {
   // Use config to set defaults for script settings
   store.dispatch('scriptSettings/setAllDefaults')
-
-  new Vue({
-    el: '#app',
-    router,
-    store,
-    render: h => h(App)
-  }).$mount('#app')
+  // Chck for auth configuration and then mount the Vue app
+  initAuth().then(() => {
+    new Vue({
+      router,
+      store,
+      render: h => h(App)
+    }).$mount('#app')
+  })
 })

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -362,51 +362,51 @@ export const commands_mixin = {
     // selection inputs.
     active_site: {
       get () { return this.selected_site },
-      set (value) { this.$store.commit('site_config/setActiveSite', value) }
+      set (value) { this.$store.commit('site_config/selected_site', value) }
     },
     active_enclosure: {
       get () { return this.selected_enclosure },
-      set (value) { this.$store.commit('site_config/setActiveEnclosure', value) }
+      set (value) { this.$store.commit('site_config/selected_enclosure', value) }
     },
     active_mount: {
       get () { return this.selected_mount },
-      set (value) { this.$store.commit('site_config/setActiveMount', value) }
+      set (value) { this.$store.commit('site_config/selected_mount', value) }
     },
     active_telescope: {
       get () { return this.selected_telescope },
-      set (value) { this.$store.commit('site_config/setActiveTelescope', value) }
+      set (value) { this.$store.commit('site_config/selected_telescope', value) }
     },
     active_rotator: {
       get () { return this.selected_rotator },
-      set (value) { this.$store.commit('site_config/setActiveRotator', value) }
+      set (value) { this.$store.commit('site_config/selected_rotator', value) }
     },
     active_focuser: {
       get () { return this.selected_focuser },
-      set (value) { this.$store.commit('site_config/setActiveFocuser', value) }
+      set (value) { this.$store.commit('site_config/selected_focuser', value) }
     },
     active_filter_wheel: {
       get () { return this.selected_filter_wheel },
-      set (value) { this.$store.commit('site_config/setActiveFilterWheel', value) }
+      set (value) { this.$store.dispatch('site_config/selected_filter_wheel', value) }
     },
     active_camera: {
       get () { return this.selected_camera },
-      set (value) { this.$store.commit('site_config/setActiveCamera', value) }
+      set (value) { this.$store.dispatch('site_config/selected_camera', value) }
     },
     active_screen: {
       get () { return this.selected_screen },
-      set (value) { this.$store.commit('site_config/setActiveScreen', value) }
+      set (value) { this.$store.commit('site_config/selected_screen', value) }
     },
     active_weather: {
       get () { return this.selected_weather },
-      set (value) { this.$store.commit('site_config/setActiveWeather', value) }
+      set (value) { this.$store.commit('site_config/selected_weather', value) }
     },
     active_sequencer: {
       get () { return this.selected_sequencer },
-      set (value) { this.$store.commit('site_config/setActiveSequencer', value) }
+      set (value) { this.$store.commit('site_config/selected_sequencer', value) }
     },
     active_selector: {
       get () { return this.selected_selector },
-      set (value) { this.$store.commit('site_config/setActiveSelector', value) }
+      set (value) { this.$store.commit('site_config/selected_selector', value) }
     },
 
     command_url: function () {

--- a/src/mixins/user_mixin.js
+++ b/src/mixins/user_mixin.js
@@ -1,60 +1,35 @@
-
+import { mapState } from 'vuex'
 export const user_mixin = {
 
   computed: {
-
-    userIsAdmin () {
-      try {
-        const user = this.$auth.user
-        const roles = user['https://photonranch.org/user_metadata'].roles
-        return roles.includes('admin')
-      } catch {
-        return false
-      }
-    },
-
-    userIsAuthenticated () {
-      const user = this.$auth.user
-      return user !== undefined
-    },
-
-    userId () {
-      return this.userIsAuthenticated
-        ? this.$auth.user.sub
-        : null
-    },
-    userName () {
-      return this.userIsAuthenticated
-        ? this.$auth.user.name
-        : null
-    },
-    userNickname () {
-      return this.userIsAuthenticated
-        ? this.$auth.user.nickname
-        : null
-    },
-    userEmail () {
-      return this.userIsAuthenticated
-        ? this.$auth.user.email
-        : null
-    }
-
+    ...mapState('user_data', [
+      'userIsAuthenticated',
+      'userIsAdmin',
+      'userId',
+      'userName',
+      'userName',
+      'userNickname',
+      'userEmail',
+      'profileUrl'
+    ])
   },
 
   methods: {
-
     login () {
-      this.$auth.loginWithPopup()
+      this.$auth.loginWithPopup().then(() => {
+        this.$store.dispatch('user_data/newUserLogin', this.$auth.user)
+      })
     },
-
     logout () {
       // save the path we will redirect back to after logout is complete
       window.localStorage.setItem('ptr_logout_redirect_path', this.$router.currentRoute.fullPath)
+
+      // update vuex
+      this.$store.dispatch('user_data/logoutUser')
+
       this.$auth.logout({
         returnTo: `${window.location.origin}/logout`
       })
     }
-
   }
-
 }

--- a/src/mixins/user_mixin.js
+++ b/src/mixins/user_mixin.js
@@ -7,7 +7,6 @@ export const user_mixin = {
       'userIsAdmin',
       'userId',
       'userName',
-      'userName',
       'userNickname',
       'userEmail',
       'profileUrl'

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,18 +12,15 @@ import sitestatus from './modules/sitestatus'
 import starprofile from './modules/analysistools/starprofile'
 import userstatus from './modules/userstatus'
 import user_interface from './modules/user_interface'
+import uiSync from './modules/uiSync'
+
+import UiSyncPlugin from './plugins/ui_sync'
 
 Vue.use(Vuex)
 
 const store = new Vuex.Store({
   plugins: [
-    // Vuex normally doesn't save between page reloads.
-    // Use this plugin to save state for the duration of a browser session.
-    // createPersistedState({
-    //    paths: [
-    //        'scriptSettings'
-    //    ]
-    // })
+    UiSyncPlugin
   ],
   modules: {
     site_config,
@@ -37,7 +34,8 @@ const store = new Vuex.Store({
     sitestatus,
     starprofile,
     userstatus,
-    user_interface
+    user_interface,
+    uiSync
   }
 })
 

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -5,6 +5,40 @@
  */
 import helpers from '../../utils/helpers'
 
+// Handlers for the different forms in the page.
+// These accept data from the user and send it to the server in a
+// variety of ways
+/*
+$('form#emit').submit(function (event) {
+    socket.emit('my_event', { data: $('#emit_data').val() });
+    return false;
+});
+$('form#broadcast').submit(function (event) {
+    socket.emit('my_broadcast_event', { data: $('#broadcast_data').val() });
+    return false;
+});
+$('form#join').submit(function (event) {
+    socket.emit('join_room', { room: $('#join_room').val() });
+    return false;
+});
+$('form#leave').submit(function (event) {
+    socket.emit('leave_room', { room: $('#leave_room').val() });
+    return false;
+});
+$('form#send_room').submit(function (event) {
+    socket.emit('my_room_event', { room: $('#room_name').val(), data: $('#room_data').val() });
+    return false;
+});
+$('form#close').submit(function (event) {
+    socket.emit('close_room', { room: $('#close_room').val() });
+    return false;
+});
+$('form#disconnect').submit(function (event) {
+    socket.emit('disconnect_request');
+    return false;
+});
+*/
+
 const state = {
 
   // Mount parameters
@@ -151,6 +185,7 @@ const mutations = {
   object_name (state, val) { state.object_name = val },
   camera_exposure (state, val) { state.camera_exposure = val },
   camera_count (state, val) { state.camera_count = val },
+  camera_area (state, val) { state.camera_area = val },
   camera_bin (state, val) { state.camera_bin = val },
   camera_dither (state, val) { state.camera_dither = val },
   camera_extract (state, val) { state.camera_extract = val },

--- a/src/store/modules/uiSync.js
+++ b/src/store/modules/uiSync.js
@@ -1,0 +1,40 @@
+const state = {
+  // Whether the user is a leader, follower, or neither.
+  ui_sync_role: 'none',
+  prev_ui_sync_role: 'none',
+
+  ui_sync_current_leader: null,
+  ui_sync_site_leaders: {}
+}
+
+const getters = {
+
+  currentLeader: (state, getters, rootState) => {
+    const site = rootState.site_config.selected_site
+    if (site in state.ui_sync_site_leaders) {
+      return state.ui_sync_site_leaders[site]
+    } else {
+      return '-'
+    }
+  }
+}
+
+const mutations = {
+
+  ui_sync_role (state, val) {
+    state.prev_ui_sync_role = state.ui_sync_role
+    state.ui_sync_role = val
+  },
+  ui_sync_current_leader (state, val) { state.ui_sync_current_leader = val },
+  ui_sync_site_leaders (state, val) { state.ui_sync_site_leaders = val }
+}
+
+const actions = { }
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+}

--- a/src/store/modules/user_data.js
+++ b/src/store/modules/user_data.js
@@ -26,6 +26,14 @@ async function getAuthRequestHeader () {
 // initial state
 const state = {
 
+  userIsAuthenticated: false,
+  userIsAdmin: false,
+  userName: '',
+  userId: '',
+  userNickname: '',
+  userEmail: '',
+  profileUrl: '',
+
   user_events: [],
   user_events_is_loading: false,
 
@@ -41,11 +49,67 @@ const state = {
 
 // getters
 const getters = {
-  api: state => state.active_api
+  api: state => state.active_api,
+  authenticatedUser: state => {
+    return {
+      admin: state.userIsAdmin,
+      name: state.userName,
+      id: state.userId,
+      nickname: state.userNickname,
+      email: state.userEmail,
+      profileUrl: state.profileUrl
+    }
+  }
+}
+
+// mutations
+const mutations = {
+
+  userIsAuthenticated (state, val) { state.userIsAuthenticated = val },
+  userIsAdmin (state, val) { state.userIsAdmin = val },
+  userName (state, val) { state.userName = val },
+  userId (state, val) { state.userId = val },
+  userNickname (state, val) { state.userNickname = val },
+  userEmail (state, val) { state.userEmail = val },
+  profileUrl (state, val) { state.profileUrl = val },
+
+  user_events (state, val) { state.user_events = val },
+  user_events_is_loading (state, val) { state.user_events_is_loading = val },
+
+  user_projects (state, val) { state.user_projects = val },
+  user_projects_is_loading (state, val) { state.user_projects_is_loading = val },
+
+  all_projects (state, val) { state.all_projects = val },
+  all_projects_is_loading (state, val) { state.all_projects_is_loading = val },
+
+  show_everyones_projects (state, val) { state.show_everyones_projects = val }
 }
 
 // actions
 const actions = {
+
+  newUserLogin ({ commit }, user) {
+    const roles = user['https://photonranch.org/user_metadata'].roles
+    const userIsAdmin = roles.includes('admin')
+
+    commit('userIsAuthenticated', true)
+    commit('userIsAdmin', userIsAdmin)
+    commit('userId', user.sub)
+    commit('userName', user.name)
+    commit('userNickname', user.nickname)
+    commit('userEmail', user.email)
+    commit('profileUrl', user.picture)
+  },
+
+  logoutUser ({ commit }) {
+    commit('userIsAuthenticated', false)
+    commit('userIsAdmin', false)
+    commit('userId', '')
+    commit('userName', '')
+    commit('userNickname', '')
+    commit('userEmail', '')
+    commit('profileUrl', '')
+  },
 
   // refreshProjectsTableData automatically chooses whether to run fetchUserProjects or fetchAllProjects
   // based on whether the projects table is set to show everyones projects or just
@@ -191,20 +255,6 @@ const actions = {
     })
   }
 
-}
-
-// mutations
-const mutations = {
-  user_events (state, val) { state.user_events = val },
-  user_events_is_loading (state, val) { state.user_events_is_loading = val },
-
-  user_projects (state, val) { state.user_projects = val },
-  user_projects_is_loading (state, val) { state.user_projects_is_loading = val },
-
-  all_projects (state, val) { state.all_projects = val },
-  all_projects_is_loading (state, val) { state.all_projects_is_loading = val },
-
-  show_everyones_projects (state, val) { state.show_everyones_projects = val }
 }
 
 export default {

--- a/src/store/modules/user_interface.js
+++ b/src/store/modules/user_interface.js
@@ -34,16 +34,16 @@ const getters = {
 
 const mutations = {
 
-  setActiveSubpage (state, subpage) {
+  selected_subpage (state, subpage) {
     state.selected_subpage = subpage
   },
-  setActiveTargetTab (state, target_tab) {
+  selected_target_tab (state, target_tab) {
     state.selected_target_tab = target_tab
   },
-  setActiveImageToolsTab (state, image_tools_tab) {
+  selected_image_tools_tab (state, image_tools_tab) {
     state.selected_image_tools_tab = image_tools_tab
   },
-  setActiveControlsTab (state, controls_tab) {
+  selected_controls_tab (state, controls_tab) {
     state.selected_controls_tab = controls_tab
   }
 

--- a/src/store/plugins/ui_sync.js
+++ b/src/store/plugins/ui_sync.js
@@ -1,0 +1,256 @@
+import { NotificationProgrammatic as Notification, DialogProgrammatic as Dialog } from 'buefy'
+
+const UiSyncPlugin = (store) => {
+  const websocketServerUrl = 'uisyncmanual-dev.us-east-1.elasticbeanstalk.com'
+  const socket = io(websocketServerUrl) // eslint-disable-line
+
+  socket.on('confirm_connect', payload => {
+    store.commit('uiSync/ui_sync_site_leaders', payload.leaders)
+  })
+
+  socket.on('my_response', function (msg) {
+    console.log('ui_sync_websocket:', msg)
+  })
+
+  socket.on('all_leaders', payload => {
+    console.log('all leaders: ', payload.leaders)
+    store.commit('uiSync/ui_sync_site_leaders', payload.leaders)
+  })
+
+  socket.on('confirm_leader_start', payload => {
+    Notification.open({
+      message: `Your session as leader of site ${payload.site} has started`,
+      position: 'is-top',
+      type: 'is-primary',
+      size: 'is-large',
+      duration: 5000 // 10 seconds
+    })
+  })
+  socket.on('confirm_leader_end', payload => {
+    Notification.open({
+      message: `Your session as leader of site ${payload.site} has ended`,
+      position: 'is-top',
+      type: 'is-primary',
+      size: 'is-large',
+      duration: 5000 // 10 seconds
+    })
+  })
+  socket.on('confirm_follower_start', payload => {
+    Notification.open({
+      message: `Your session as follower of site ${payload.site} has started`,
+      position: 'is-top',
+      type: 'is-primary',
+      size: 'is-large',
+      duration: 5000 // 10 seconds
+    })
+  })
+  socket.on('confirm_follower_end', payload => {
+    Notification.open({
+      message: `Your session as follower of site ${payload.site} has ended`,
+      position: 'is-top',
+      type: 'is-primary',
+      size: 'is-large',
+      duration: 5000 // 10 seconds
+    })
+  })
+
+  socket.on('new_state', payload => {
+    // Followers should update any new incoming state
+    if (store.state.uiSync.ui_sync_role == 'follower') {
+      const key = payload.key
+      const val = payload.new_val
+      console.log('new state: ', key, val)
+      store.commit(key, val)
+    }
+  })
+
+  // Handle a leader ending their leading role for any current followers
+  socket.on('no_more_leader', payload => {
+    Notification.open({
+      message: `Notice: ${payload.leader_name} has stopped syncing their UI state.`,
+      position: 'is-bottom',
+      type: 'is-warning',
+      size: 'is-large',
+      duration: 10000 // 10 seconds
+    })
+  })
+
+  socket.on('full_state_snapshot', payload => {
+    console.log('restoring full state', payload)
+    const leader = payload.leader.name
+    const full_state = payload.state_snapshot
+
+    // Save leader info
+    store.commit('uiSync/ui_sync_current_leader', payload.leader)
+
+    // Update all state from leader state snapshot
+    Object.keys(full_state).forEach(key => {
+      store.commit(key, full_state[key])
+    })
+    // Notify user of the leader
+    const htmlMessage = `<p> Session leader: ${leader}</p>
+            <p> Changes that the leader makes to their user interface will be changed in your page too. 
+            For example, if they change the selected exposure time, that number will show up in 
+            your camera tab. Or if they switch to view the enclosure tab, your view will switch too.</p> 
+            <br>
+            <p>Changes you make as follower will not be visible to anyone. Be careful if you change 
+            something, as it may be unclear later whether the leader is using that value or not</p>
+            <br>
+            <p> If you ever need to re-sync your state with the leader, 
+            simply stop following and then start following again.</p>`
+    Dialog.confirm({
+      title: 'UI Sync Turned On',
+      message: htmlMessage,
+      position: 'is-top',
+      cancelText: 'Stop Following',
+      confirmText: 'Got it!',
+      type: 'is-info',
+      canCancel: ['button'],
+      indefinite: true,
+      onCancel: () => { store.commit('uiSync/ui_sync_role', 'none') }
+    })
+  })
+
+  // For command_param mutations, also emit to websocket
+  store.subscribe((mutation, state) => {
+    // Broadcast state if user is leader
+    if (state.uiSync.ui_sync_role == 'leader' && mutation.type != 'uiSync/ui_sync_role') {
+      if (mutation.type.startsWith('command_params/') ||
+        mutation.type.startsWith('user_interface/') ||
+        mutation.type.startsWith('site_config/selected_')) {
+        const payload = {
+          site: store.state.site_config.selected_site,
+          mutation_name: mutation.type,
+          new_val: mutation.payload
+        }
+        console.log('payload', payload)
+        socket.emit('ui_change', payload)
+      }
+    }
+
+    // Handle user changing roles between [leader, follower, none]
+    else if (mutation.type == 'uiSync/ui_sync_role') {
+      // Leader to follower
+      if (state.uiSync.prev_ui_sync_role == 'leader' && mutation.payload == 'follower') {
+        endLeaderSession(store, socket)
+        startFollowerSession(store, socket)
+      }
+      // Leader to none
+      else if (state.uiSync.prev_ui_sync_role == 'leader' && mutation.payload == 'none') {
+        endLeaderSession(store, socket)
+      }
+      // Follower to leader
+      else if (state.uiSync.prev_ui_sync_role == 'follower' && mutation.payload == 'leader') {
+        endFollowerSession(store, socket)
+        startLeaderSession(store, socket)
+      }
+      // Follower to none
+      else if (state.uiSync.prev_ui_sync_role == 'follower' && mutation.payload == 'none') {
+        endFollowerSession(store, socket)
+      }
+      // None to leader
+      else if (state.uiSync.prev_ui_sync_role == 'none' && mutation.payload == 'leader') {
+        startLeaderSession(store, socket)
+      }
+      // None to follower
+      else if (state.uiSync.prev_ui_sync_role == 'none' && mutation.payload == 'follower') {
+        startFollowerSession(store, socket)
+      }
+    }
+  }
+
+  )
+}
+
+function startLeaderSession (store, socket) {
+  // get a full snapshot of the state we want to sync
+  const fullStateSnapshot = createFullStateSnapshot(store)
+
+  const payload = JSON.stringify({
+    site: store.state.site_config.selected_site,
+    full_state_snapshot: fullStateSnapshot,
+    leader: store.getters['user_data/authenticatedUser']
+  })
+  socket.emit('new_leader', payload)
+}
+
+function endLeaderSession (store, socket) {
+  socket.emit('remove_leader', { site: store.state.site_config.selected_site })
+}
+
+function startFollowerSession (store, socket) {
+  const payload = { site: store.state.site_config.selected_site }
+  socket.emit('join_room', payload)
+}
+
+function endFollowerSession (store, socket) {
+  const payload = { site: store.state.site_config.selected_site }
+  socket.emit('leave_room', payload)
+}
+
+/**
+ *
+ * This method operates on a vuex store, transforming a subset of state that we want into an
+ * object where each key is the name of the mutation used to set the val.
+ *
+ * This is so that when the server sends back the full state snapshot, it's easy for clients
+ * to simply apply all the mutations to get an identical state as the leader
+ *
+ * In order for this to work, the state we want to sync must live in a vuex module where the
+ * name of the state's mutation follows the format '<vuexModuleName>/<stateItemName>'
+ *
+ * Example object returned by this method:
+ * {
+ *  "command_params/mount_ra": 12.34,
+ *  "command_params/mount_dec": 56.78,
+ *  ...
+ *  "user_interface/selected_subpage": "home",
+ *  "user_interface/selected_target_tab": "telescope_controls"
+ *  ...
+ * }
+ *
+ * @param Object store: the full vuex store
+ * @returns Object
+ */
+function createFullStateSnapshot (store) {
+  // We're only syncing a subset of the vuex store, so first select the state of interest.
+  // For now, it's almost everything in command_params and user_interface.
+  const vuexModulesToSync = ['command_params', 'user_interface', 'site_config']
+
+  // This array will hold objects with a single key/val for each state datum.
+  let fullStateArray = []
+
+  // Populate fullStateArray
+  vuexModulesToSync.forEach(moduleName => {
+    // gather the array of { key: val } elements separately for each vuex module
+    const moduleArray = Object.keys(store.state[moduleName]).map(key => {
+      const mutationName = `${moduleName}/${key}`
+      return { [mutationName]: store.state[moduleName][key] }
+    })
+    // then add them to the full array
+    fullStateArray = [...fullStateArray, ...moduleArray]
+  })
+
+  // From this array, create a single object that contains all the key/val pairs
+  const fullStateSnapshotObject = fullStateArray.reduce((accumulator, currentValue) => {
+    return Object.assign(accumulator, currentValue)
+  }, {})
+
+  // Finally, remove any specific values we don't want to sync
+  const doNotSyncTheseKeys = [
+    'site_config/test_sites',
+    'site_config/global_config',
+    'site_config/is_site_selected',
+    'site_config/did_config_load_yet',
+    'site_config/selected_site',
+    'site_config/prev_selected_site',
+    'site_config/selector_exists'
+  ]
+  doNotSyncTheseKeys.forEach(key => {
+    delete fullStateSnapshotObject[key]
+  })
+
+  return fullStateSnapshotObject
+}
+
+export default UiSyncPlugin

--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -147,7 +147,10 @@ export default {
   },
 
   beforeDestroy () {
-    this.$store.commit('site_config/removeActiveSite')
+    // Stop UI sync if the user is leader or follower
+    this.$store.commit('uiSync/ui_sync_role', 'none')
+
+    this.$store.commit('site_config/remove_selected_site')
     this.$store.dispatch('images/display_placeholder_image')
     datastreamer.close()
   },
@@ -162,7 +165,7 @@ export default {
   computed: {
     active_subpage: {
       get () { return this.$store.state.user_interface.selected_subpage },
-      set (value) { this.$store.commit('user_interface/setActiveSubpage', value) }
+      set (value) { this.$store.commit('user_interface/selected_subpage', value) }
       // subpage set to home by default in user_interface
     }
   },
@@ -179,6 +182,9 @@ export default {
     // Do this whenever the selected site changes
     // 'sitecode' argument is the new site being navigated to, not the old one.
     site_changed_routine (sitecode) {
+      // Stop UI sync if the user is leader or follower
+      this.$store.commit('uiSync/ui_sync_role', 'none')
+
       // Update the active devices
       this.$store.dispatch('site_config/set_default_active_devices', sitecode)
 


### PR DESCRIPTION
These changes are centered around the inclusion of a prototype for sharing UI state between different browsers. The frontend connects to a websocket server and either sends or receives changes to the UI state. 

The UI state that is synced includes data in any fields used for specifying observatory commands, as well as the visible tab interface used for commands. 

For example, if a user with the leader role changes increases the camera exposure time to 5 seconds, then all followers at that site will see the value 5 appear in the exposure text box. Then if the leader switches to the telescope tab to set a new pointing, all followers will also see their interface switch over to the telescope tab as well.

UI syncing is confined to a per-site basis, and users who switch sites will automatically end their ui-sync session. 

----

This implementation is not fully polished yet. If it proves useful, the following improvements are possible:
- Better location for the buttons where users can turn the UI sync on or off. Could be easier to find, and the current status (follower/leader/none) of the user could be more obvious.
- Add some indication when a follower's state is out of sync with the leader's. 
- Include a way to automatically remove a leader after some period of inactivity so that a stale session doesn't block others from leading. 
- Include a way for admins to end a leader's session