### PR TITLE
Feature/mosaic fields

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -372,8 +372,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                min="-4.5"
-                max="4.5"
+                :min="minWidth"
+                :max="maxWidth"
                 step="0.1"
               />
             </b-field>
@@ -386,8 +386,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                min="-4.5"
-                max="4.5"
+                :min="minHeight"
+                :max="maxHeight"
                 step="0.1"
               />
             </b-field>
@@ -838,7 +838,9 @@ const mapStateToComputed = (vuexModule, propertyNames) => {
 
 export default {
   name: 'CreateProjectForm',
-  props: ['sitecode', 'project_to_load'],
+  // passing 'n' as a prop to be able to adjust height and width depending on the zoom selection
+  // have to specify the type of props for all 3
+  props: ['sitecode', 'project_to_load', 'n'],
   mixins: [target_names, user_mixin],
   components: {
     RightAscensionInput,
@@ -865,6 +867,10 @@ export default {
         'Mosaic deg.', 'Mosaic arcmin.', 'Full', 'Big sq.',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
       ],
+      minWidth: -4.5 * 60,
+      maxWidth: 4.5 * 60,
+      minHeight: -4.5 * 60,
+      maxHeight: 4.5 * 60,
       site: this.sitecode,
       warn: {
         project_name: false,
@@ -973,6 +979,11 @@ export default {
       this.exposures = this.exposures.map((obj, index) => {
         return index === indexToMatch ? { ...obj, [key]: val } : obj
       })
+    },
+
+    isZoomArcminute () {
+      // console.log('Current Zoom:', this.exposures[this.n - 1].zoom)
+      return this.exposures[this.n - 1].zoom === 'Mosaic arcmin.'
     },
 
     clearProjectForm () {
@@ -1262,6 +1273,24 @@ export default {
     project_name_changed () {
       return this.modifying_existing_project && this.loaded_project_name != this.project_name
     },
+
+    adjustedWidth: {
+      get () {
+        return this.exposures[this.n - 1].width // Directly return the value without any condition
+      },
+      set (value) {
+        this.exposures[this.n - 1].width = value
+      }
+    },
+    adjustedHeight: {
+      get () {
+        return this.isZoomArcminute() ? this.exposures[this.n - 1].height * 60 : this.exposures[this.n - 1].height
+      },
+      set (value) {
+        this.exposures[this.n - 1].height = this.isZoomArcminute() ? value / 60 : value
+      }
+    },
+
     ...mapGetters('command_params', [
       'mount_ra',
       'mount_dec',

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -372,8 +372,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="minWidth"
-                :max="maxWidth"
+                :min="-4.5"
+                :max="4.5"
                 step="0.1"
               />
             </b-field>
@@ -386,8 +386,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="minHeight"
-                :max="maxHeight"
+                :min="-4.5"
+                :max="4.5"
                 step="0.1"
               />
             </b-field>
@@ -840,7 +840,7 @@ export default {
   name: 'CreateProjectForm',
   // passing 'n' as a prop to be able to adjust height and width depending on the zoom selection
   // have to specify the type of props for all 3
-  props: ['sitecode', 'project_to_load', 'n'],
+  props: ['sitecode', 'project_to_load'],
   mixins: [target_names, user_mixin],
   components: {
     RightAscensionInput,
@@ -979,11 +979,6 @@ export default {
       this.exposures = this.exposures.map((obj, index) => {
         return index === indexToMatch ? { ...obj, [key]: val } : obj
       })
-    },
-
-    isZoomArcminute () {
-      // console.log('Current Zoom:', this.exposures[this.n - 1].zoom)
-      return this.exposures[this.n - 1].zoom === 'Mosaic arcmin.'
     },
 
     clearProjectForm () {
@@ -1272,23 +1267,6 @@ export default {
     // True if we're modifying a project and the name is changed.
     project_name_changed () {
       return this.modifying_existing_project && this.loaded_project_name != this.project_name
-    },
-
-    adjustedWidth: {
-      get () {
-        return this.exposures[this.n - 1].width // Directly return the value without any condition
-      },
-      set (value) {
-        this.exposures[this.n - 1].width = value
-      }
-    },
-    adjustedHeight: {
-      get () {
-        return this.isZoomArcminute() ? this.exposures[this.n - 1].height * 60 : this.exposures[this.n - 1].height
-      },
-      set (value) {
-        this.exposures[this.n - 1].height = this.isZoomArcminute() ? value / 60 : value
-      }
     },
 
     ...mapGetters('command_params', [

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -838,8 +838,6 @@ const mapStateToComputed = (vuexModule, propertyNames) => {
 
 export default {
   name: 'CreateProjectForm',
-  // passing 'n' as a prop to be able to adjust height and width depending on the zoom selection
-  // have to specify the type of props for all 3
   props: ['sitecode', 'project_to_load'],
   mixins: [target_names, user_mixin],
   components: {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -374,7 +374,7 @@
                 type="number"
                 :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minWidth * 60 : minWidth"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidth * 60 : maxWidth"
-                step="0.1"
+                :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
               />
             </b-field>
             <b-field
@@ -388,7 +388,7 @@
                 type="number"
                 :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minHeight * 60 : minHeight"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeight * 60 : maxHeight"
-                step="0.1"
+                :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
               />
             </b-field>
             <b-field
@@ -871,6 +871,7 @@ export default {
       maxWidth: 4.5,
       minHeight: -4.5,
       maxHeight: 4.5,
+      conditionalStep: 0.1,
       site: this.sitecode,
       warn: {
         project_name: false,

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -372,8 +372,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="-4.5"
-                :max="4.5"
+                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minWidth * 60 : minWidth"
+                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidth * 60 : maxWidth"
                 step="0.1"
               />
             </b-field>
@@ -386,8 +386,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="-4.5"
-                :max="4.5"
+                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minHeight * 60 : minHeight"
+                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeight * 60 : maxHeight"
                 step="0.1"
               />
             </b-field>
@@ -867,10 +867,10 @@ export default {
         'Mosaic deg.', 'Mosaic arcmin.', 'Full', 'Big sq.',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
       ],
-      minWidth: -4.5 * 60,
-      maxWidth: 4.5 * 60,
-      minHeight: -4.5 * 60,
-      maxHeight: 4.5 * 60,
+      minWidth: -4.5,
+      maxWidth: 4.5,
+      minHeight: -4.5,
+      maxHeight: 4.5,
       site: this.sitecode,
       warn: {
         project_name: false,

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -347,10 +347,10 @@
               </b-select>
             </b-field>
             <b-field
-              :label="n==1 ? 'Area' : ''"
+              :label="n==1 ? 'Zoom in' : ''"
             >
               <b-select
-                v-model="exposures[n-1].area"
+                v-model="exposures[n-1].zoomin"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
               >
@@ -359,9 +359,48 @@
                   :key="index"
                   :value="val"
                 >
-                  {{ val.toLowerCase() }}
+                  {{ val }}
                 </option>
               </b-select>
+            </b-field>
+            <b-field
+              :label="n==1 ? 'Width' : ''"
+              style="width: 80px;"
+            >
+              <b-input
+                v-model="exposures[n-1].width"
+                size="is-small"
+                :disabled="!exposures[n-1].active"
+                type="number"
+                min="-4.5"
+                max="4.5"
+              />
+            </b-field>
+            <b-field
+              :label="n==1 ? 'Height' : ''"
+              style="width: 80px;"
+            >
+              <b-input
+                v-model="exposures[n-1].height"
+                size="is-small"
+                :disabled="!exposures[n-1].active"
+                type="number"
+                min="-4.5"
+                max="4.5"
+              />
+            </b-field>
+            <b-field
+              :label="n==1 ? 'Angle' : ''"
+              style="width: 80px;"
+            >
+              <b-input
+                v-model="exposures[n-1].angle"
+                size="is-small"
+                :disabled="!exposures[n-1].active"
+                type="number"
+                min="-45.0"
+                max="45.0"
+              />
             </b-field>
             <div />
           </div>
@@ -820,8 +859,8 @@ export default {
       max_fits_header_length: 68,
       generic_filter_list: ['Lum', 'Red', 'Green', 'Blue', 'HA', 'O3', 'S2', 'EXO'],
       generic_camera_areas: [
-        '600%', '500%', '400%', '300%', '220%', '133%',
-        'FULL', 'SQUARE', '71%', '50%', '35%', '25%', '12%'
+        'Sel.', '220%', '133%',
+        '100%', 'Sqr.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
       ],
       site: this.sitecode,
       warn: {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -372,8 +372,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minWidth * 60 : minWidth"
-                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidth * 60 : maxWidth"
+                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minWidthDegrees * degreesToArcminutes : minWidthDegrees"
+                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidthDegrees * degreesToArcminutes : maxWidthDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
               />
             </b-field>
@@ -386,8 +386,8 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minHeight * 60 : minHeight"
-                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeight * 60 : maxHeight"
+                :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minHeightDegrees * degreesToArcminutes : minHeightDegrees"
+                :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeightDegrees * degreesToArcminutes : maxHeightDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
               />
             </b-field>
@@ -865,10 +865,11 @@ export default {
         'Mosaic deg.', 'Mosaic arcmin.', 'Full', 'Big sq.',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
       ],
-      minWidth: -4.5,
-      maxWidth: 4.5,
-      minHeight: -4.5,
-      maxHeight: 4.5,
+      minWidthDegrees: -4.5,
+      maxWidthDegrees: 4.5,
+      minHeightDegrees: -4.5,
+      maxHeightDegrees: 4.5,
+      degreesToArcminutes: 60,
       conditionalStep: 0.1,
       site: this.sitecode,
       warn: {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -347,10 +347,10 @@
               </b-select>
             </b-field>
             <b-field
-              :label="n==1 ? 'Zoom in' : ''"
+              :label="n==1 ? 'Zoom' : ''"
             >
               <b-select
-                v-model="exposures[n-1].zoomin"
+                v-model="exposures[n-1].zoom"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
               >
@@ -374,6 +374,7 @@
                 type="number"
                 min="-4.5"
                 max="4.5"
+                step="0.1"
               />
             </b-field>
             <b-field
@@ -387,6 +388,7 @@
                 type="number"
                 min="-4.5"
                 max="4.5"
+                step="0.1"
               />
             </b-field>
             <b-field
@@ -400,6 +402,7 @@
                 type="number"
                 min="-45.0"
                 max="45.0"
+                step="5"
               />
             </b-field>
             <div />
@@ -859,8 +862,8 @@ export default {
       max_fits_header_length: 68,
       generic_filter_list: ['Lum', 'Red', 'Green', 'Blue', 'HA', 'O3', 'S2', 'EXO'],
       generic_camera_areas: [
-        'Sel.', '220%', '133%',
-        '100%', 'Sqr.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
+        'Mosaic deg.', 'Mosaic arcmin.', 'Full', 'Big sq.',
+        'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
       ],
       site: this.sitecode,
       warn: {

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -20,8 +20,11 @@ const state = {
       imtype: 'light',
       exposure: 1,
       filter: 'Lum',
-      area: 'FULL',
-      bin: 'optimal'
+      zoomin: '100%',
+      bin: 'optimal',
+      width: '0.0',
+      height: '0.0',
+      angle: '0.0'
     }
   ],
   targets: [

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -20,7 +20,7 @@ const state = {
       imtype: 'light',
       exposure: 1,
       filter: 'Lum',
-      zoomin: '100%',
+      zoom: 'Full',
       bin: 'optimal',
       width: '0.0',
       height: '0.0',
@@ -115,7 +115,7 @@ const getters = {
         .filter(e => e.active)
         .map(({ active, ...stuff_to_keep }) => stuff_to_keep),
       // Nested arrays such that
-      // remaining[target_index][exposure_index] = number of remaining exposures
+      // remaining[exposure_index] = number of remaining exposures
       remaining: state.exposures.map(e => parseInt(e.count)),
       // Empty nested arrays such that
       // project_data[exposure_index] = [array of filenames]
@@ -193,8 +193,11 @@ const actions = {
         imtype: 'light',
         exposure: 1,
         filter: 'Lum',
-        area: 'FULL',
-        bin: 'optimal'
+        zoom: 'Full',
+        bin: 'optimal',
+        width: '0.0',
+        height: '0.0',
+        angle: '0.0'
       }
     ])
     commit('exposures_index', 1)


### PR DESCRIPTION
### FEATURE UPDATE: Added exposure fields under Projects tab with conditional adjustments 

### DESCRIPTION
**Background:**
Under the Projects tab, there was a field previously named _area_. This field has been renamed now to _zoom_. The options for _zoom_ were modified. Additionally, the fields _width_, _height_, and _angle_ were introduced, per @wrosing [request](https://lcogt.slack.com/archives/CLAQ9U79B/p1694890592547499)



**Implementation:**
The field _area_ was renamed to zoom, and its predefined values were modified. These values can be found in the data to be returned, under `generic_camera_areas` in the CreateProjectForm component. In addition to this, the fields _width_, _height_, and _angle_ were integrated. The default value for _zoom_ is set to 'Full', and the default value for _height, width,_ and _angle_ are set to '0.0'. The default values can be found in the file project_params.js under the `exposures` array of objects.

To enhance these new fields, conditions were implemented to check the selected value of the _zoom_ field.  When 'Mosaic arcmin.' is selected, the constraints of the _width_ and _height_ fields adapt to range between -270 and 270, with an increment step of 1, allowing for more user-friendly modifications in arcminutes. For all other selections, representing degrees, the _width_ and _height_ fields are constrained to range between -4.5 and 4.5, with a finer increment step of 0.1, ensuring precise adjustments. The constraints of the _angle_ field are set to -45.0 to 45.0 with an increment step of 5.



**Features:**
1. Field Renovation: The field area was renamed to _zoom_. The fields of _width, height,_ and _angle_ fields were also introduced.
2. Value Modifications: The predefined values of the _zoom_ field were updated. The purpose of some of the changes of these options is  meant to reflect a subframe drawn on the current image on the user's screen. This is only useful for real-time sessions.
3. Conditional Adjustments: The system alters the min, max, and step of _width_ and _height_ fields based on the selected _zoom_ value, ensuring a user-friendly experience.



### VISUALS


**Before renaming to _zoom_**
<img width="1719" alt="Screenshot 2023-09-21 at 11 54 40 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/a08e841a-2de4-4b22-9234-aac25e8f3e3e">



**Previous values of _area_ (now _zoom_)**
<img width="1721" alt="Screenshot 2023-09-21 at 11 55 20 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/99504fef-50ad-4804-b566-5a31ab66d450">



**After renaming and with addition of new fields**
<img width="1718" alt="Screenshot 2023-09-21 at 12 08 15 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/799099b8-aa4f-448c-be8f-01a522d9dcda">



**New options for _zoom_ field**
<img width="1710" alt="Screenshot 2023-09-21 at 12 12 40 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/599ebc83-1331-44d2-9b51-cb8f7ab206f8">



**All new fields within constraints**
<img width="1720" alt="Screenshot 2023-09-21 at 12 26 20 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/0ef2fe48-0b91-47c2-908a-470d311b4460">



**'Mosaic arcmin.' is selected and _height_ exceeds the max**
<img width="1720" alt="Screenshot 2023-09-21 at 12 19 56 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/f40b758b-8933-4464-90d3-8bab0bd52436">



**'Mosaic deg.' is selected and _width_ does not meet the min**
<img width="1720" alt="Screenshot 2023-09-21 at 12 23 10 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/47cd1e5f-5d37-45d5-be07-b62b6a38e708">



**Recording of min and max changing as 'Mosaic arcmin.' is selected**
https://github.com/LCOGT/ptr_ui/assets/54489472/762c87f4-f750-456a-a237-e3719f44a3c7












