### PR TITLE
Feature/update grouped images

### DIFF
--- a/src/components/ImageDisplay/ControlRoomImages.vue
+++ b/src/components/ImageDisplay/ControlRoomImages.vue
@@ -23,7 +23,6 @@
       <thumbnail-row
         class="data-thumbs"
         :images="recent_images"
-        :grouped_images="grouped_images"
         :selected_image="current_image.image_id"
         @thumbnailClicked="set_current_image"
       />
@@ -60,6 +59,7 @@ export default {
   props: {
     sitecode: String
   },
+
   methods: {
     ...mapActions('images', [
       'set_current_image'

--- a/src/components/ImageDisplay/ControlRoomImages.vue
+++ b/src/components/ImageDisplay/ControlRoomImages.vue
@@ -59,7 +59,6 @@ export default {
   props: {
     sitecode: String
   },
-
   methods: {
     ...mapActions('images', [
       'set_current_image'

--- a/src/components/ImageDisplay/ThumbnailRow.vue
+++ b/src/components/ImageDisplay/ThumbnailRow.vue
@@ -1,32 +1,21 @@
 <template>
-  <div
-    v-if="grouped_images.imageGroups && Object.keys(grouped_images.imageGroups).length > 0"
-    class="images"
-  >
+  <div class="images">
     <img
-      v-for="(item, SMARTSTK) in grouped_images.imageGroups"
-      :key="SMARTSTK"
+      v-for="(item, index) in images"
+      :key="index"
       :src="thumbnailWithFallback(item)"
       onerror="this.onerror=null;this.src='https://via.placeholder.com/60/FF0000/FFFFFF?text=jpg'"
-      :title="item[0].baseFilename"
-      :class="{'selected_thumbnail' : item[0].image_id == selected_image}"
+      :title="item.base_filename"
+      :class="{'selected_thumbnail' : item.image_id == selected_image}"
       loading="lazy"
       class="recent-image"
-      @click="setActiveImage(item[0])"
-    >
-  </div>
-  <div
-    v-else
-    class="placeholder"
-  >
-    <img
-      :src="'https://via.placeholder.com/768?text=no+jpg+preview+available'"
-      class="recent-image"
+      @click="setActiveImage(item)"
     >
   </div>
 </template>
 
 <script>
+
 export default {
   name: 'ThumbnailRow',
   props: {
@@ -37,38 +26,31 @@ export default {
     selected_image: {
       type: Number,
       required: false
-    },
-    grouped_images: {
-      default: () => ({}),
-      type: Object,
-      required: true
     }
+    // grouped_images: {
+    //   default: () => ({}),
+    //   type: Object,
+    //   required: true
+    // }
   },
-  mounted () {
-    console.log('Mounted Grouped Images:', this.grouped_images)
-  },
-  // watch: {
-  //   grouped_images: {
-  //     handler (newVal, oldVal) {
-  //       console.log('New Value:', JSON.stringify(newVal, null, 2))
-  //       console.log('Old Value:', JSON.stringify(oldVal, null, 2))
-  //     },
-  //     deep: true,
-  //     immediate: true
-  //   }
-  // },
   methods: {
     setActiveImage (item) {
       this.$emit('thumbnailClicked', item)
     },
-
     thumbnailWithFallback (item) {
-      let thumbnailCover = item && item[0] && item[0].jpg_thumbnail_url
-      if (!thumbnailCover) {
-        thumbnailCover = item && item[0] && item[0].jpg_url
-      }
-      return thumbnailCover || 'https://via.placeholder.com/768?text=no+jpg+preview+available'
+      return item.jpg_thumbnail_url || item.jpg_url
     }
+    // setActiveImage (item) {
+    //   this.$emit('thumbnailClicked', item)
+    // },
+
+    // thumbnailWithFallback (item) {
+    //   let thumbnailCover = item && item[0] && item[0].jpg_thumbnail_url
+    //   if (!thumbnailCover) {
+    //     thumbnailCover = item && item[0] && item[0].jpg_url
+    //   }
+    //   return thumbnailCover || 'https://via.placeholder.com/768?text=no+jpg+preview+available'
+    // }
   }
 }
 </script>

--- a/src/components/ImageDisplay/ThumbnailRow.vue
+++ b/src/components/ImageDisplay/ThumbnailRow.vue
@@ -39,21 +39,24 @@ export default {
       required: false
     },
     grouped_images: {
+      default: () => ({}),
       type: Object,
-      default: () => {},
       required: true
     }
   },
-  watch: {
-    groupedImagesFromStore: {
-      handler (newVal) {
-        console.log('groupedImagesFromStore changed:', newVal)
-        // you can do something here when the state changes.
-      },
-      deep: true,
-      immediate: true
-    }
+  mounted () {
+    console.log('Mounted Grouped Images:', this.grouped_images)
   },
+  // watch: {
+  //   grouped_images: {
+  //     handler (newVal, oldVal) {
+  //       console.log('New Value:', JSON.stringify(newVal, null, 2))
+  //       console.log('Old Value:', JSON.stringify(oldVal, null, 2))
+  //     },
+  //     deep: true,
+  //     immediate: true
+  //   }
+  // },
   methods: {
     setActiveImage (item) {
       this.$emit('thumbnailClicked', item)

--- a/src/components/ImageDisplay/ThumbnailRow.vue
+++ b/src/components/ImageDisplay/ThumbnailRow.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script>
-
 export default {
   name: 'ThumbnailRow',
   props: {
@@ -45,7 +44,16 @@ export default {
       required: true
     }
   },
-
+  watch: {
+    groupedImagesFromStore: {
+      handler (newVal) {
+        console.log('groupedImagesFromStore changed:', newVal)
+        // you can do something here when the state changes.
+      },
+      deep: true,
+      immediate: true
+    }
+  },
   methods: {
     setActiveImage (item) {
       this.$emit('thumbnailClicked', item)

--- a/src/components/ImageDisplay/ThumbnailRow.vue
+++ b/src/components/ImageDisplay/ThumbnailRow.vue
@@ -27,11 +27,6 @@ export default {
       type: Number,
       required: false
     }
-    // grouped_images: {
-    //   default: () => ({}),
-    //   type: Object,
-    //   required: true
-    // }
   },
   methods: {
     setActiveImage (item) {
@@ -40,17 +35,6 @@ export default {
     thumbnailWithFallback (item) {
       return item.jpg_thumbnail_url || item.jpg_url
     }
-    // setActiveImage (item) {
-    //   this.$emit('thumbnailClicked', item)
-    // },
-
-    // thumbnailWithFallback (item) {
-    //   let thumbnailCover = item && item[0] && item[0].jpg_thumbnail_url
-    //   if (!thumbnailCover) {
-    //     thumbnailCover = item && item[0] && item[0].jpg_url
-    //   }
-    //   return thumbnailCover || 'https://via.placeholder.com/768?text=no+jpg+preview+available'
-    // }
   }
 }
 </script>

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -384,8 +384,7 @@ export default {
 
     ...mapState('images', [
       'recent_images',
-      'current_image',
-      'grouped_images'
+      'current_image'
     ]),
 
     ...mapGetters('images', [

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -24,8 +24,7 @@
           />
           <thumbnail-row
             class="data-thumbs"
-            :images="recent_images"
-            :grouped_images="grouped_images"
+            :images="$store.getters['images/recent_images_condensed']"
             :selected_image="current_image.image_id"
             @thumbnailClicked="setActiveImage"
           />

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -130,10 +130,10 @@ const actions = {
      * image, and add it into the 'latest_images' list.
      *
      */
-
   update_new_image ({ commit, state, rootState, dispatch }, new_base_filename) {
     // No need to get the latest if the new image is from a different site.
     const site = rootState.site_config.selected_site
+
     // Get the image's site of origin from the beginning of the filename.
     const image_site_origin = new_base_filename.split('-')[0]
     if (site != image_site_origin) {
@@ -152,8 +152,8 @@ const actions = {
       if (response.data.length == 0) {
         return
       }
-
       const new_image = response.data
+      console.log('new_image,', new_image)
       const recent_images = state.recent_images
 
       // Don't show add the image if the user is requesting their data
@@ -175,10 +175,12 @@ const actions = {
       if (old_image_index == -1) {
         const updated_recent_images = [new_image, ...recent_images]
         commit('setRecentImages', updated_recent_images)
+        dispatch('group_images')
       }
       // Otherwise, replace the old version with the new one we fetched.
       else {
         recent_images[old_image_index] = new_image
+        dispatch('group_images')
       }
 
       // We don't have a toggle implemented yet.
@@ -327,7 +329,6 @@ const actions = {
     // If a query size is specified, use the old method of retrieving X images
     const querySize = num_images // || 25 (original default);
     url = rootState.api_endpoints.active_api + `/${site}/latest_images/${querySize}`
-
     // If a user is logged in and they want to see only their data,
     // add their id as a query string param for the api call.
     if (state.show_user_data_only && userid) {
@@ -388,7 +389,6 @@ const actions = {
 
     // Query for site's local noon to noon
     url = rootState.api_endpoints.active_api + '/filtered_images'
-
     let queryStart = null
     let queryEnd = null
 
@@ -473,7 +473,6 @@ const actions = {
 
     await axios(body).then(async response => {
       response = response.data
-
       // Empty response:
       if (response.length == 0) {
         dispatch('display_placeholder_image')
@@ -500,7 +499,7 @@ const actions = {
       axios.get(url).then(response => {
         // Handle case if no info image exists
         if (response.status == 204) {
-          commit('setInfoImage', { info_image: { jpg_url: '' }, channel }) // reset to default empty value
+          commit('setInfoImage', { info_image: { jpg_url: '' }, channel }) // reset to default empty value 
           return
         }
         // Only update the current image if currently set to the old info image

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -47,7 +47,7 @@ const state = {
 
   // grouped_images: object where images are grouped based on their SMARTSTK value
   // Before the action group_images, there's an example of what this object looks like after being populated
-  grouped_images: {},
+  // grouped_images: {},
 
   show_user_data_only: false,
 
@@ -59,7 +59,7 @@ const getters = {
   current_image: state => state.current_image,
   recent_images: state => state.recent_images,
   user_images: state => state.user_images,
-  grouped_images: state => state.grouped_images,
+  // grouped_images: state => state.grouped_images,
   recent_images_condensed: state => {
     // First, generate a map of maximum SSTKNUM for each SMARTSTK
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
@@ -106,7 +106,7 @@ const getters = {
 const mutations = {
   setCurrentImage (state, the_current_image) { state.current_image = the_current_image },
   setRecentImages (state, recent_image_list) { state.recent_images = recent_image_list },
-  setGroupedImages (state, grouped_images) { state.grouped_images = grouped_images },
+  // setGroupedImages (state, grouped_images) { state.grouped_images = grouped_images },
   setUserImages (state, user_images_list) { state.user_images = user_images_list },
   show_user_data_only (state, val) { state.show_user_data_only = val },
   live_data (state, val) { state.live_data = val },

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -65,8 +65,9 @@ const getters = {
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
       if (!cur.header || !cur.header.SMARTSTK || !cur.header.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM
 
-      if (!acc[cur.header.SMARTSTK] || Number(cur.header.SSTKNUM) > Number(acc[cur.header.SMARTSTK])) {
-        acc[cur.header.SMARTSTK] = cur.header.SSTKNUM
+      const num = parseInt(cur.header.SSTKNUM) // convert string to number
+      if (!acc[cur.header.SMARTSTK] || num > acc[cur.header.SMARTSTK]) {
+        acc[cur.header.SMARTSTK] = num
       }
       return acc
     }, {})

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -331,9 +331,9 @@ const actions = {
 
   // Resets grouped_images to an empty object
   // Dispatched when a different site is selected
-  reset_grouped_images ({ commit }) {
-    commit('setGroupedImages', {})
-  },
+  // reset_grouped_images ({ commit }) {
+  //   commit('setGroupedImages', {})
+  // },
 
   async load_latest_x_images ({ dispatch, commit, state, rootState }, num_images) {
     // Old method of loading only a certain amount of images
@@ -574,7 +574,7 @@ const actions = {
     }
     commit('setRecentImages', [placeholder_image])
     commit('setCurrentImage', placeholder_image)
-    dispatch('reset_grouped_images')
+    // dispatch('reset_grouped_images')
   },
 
   // Set this_image as the current displayed image
@@ -613,10 +613,10 @@ const actions = {
     commit('setCurrentImage', first_image)
   },
 
-  set_grouped_images ({ commit, state }) {
-    const grouped_images_local = state.grouped_images
-    commit('setGroupedImages', { ...grouped_images_local })
-  },
+  // set_grouped_images ({ commit, state }) {
+  //   const grouped_images_local = state.grouped_images
+  //   commit('setGroupedImages', { ...grouped_images_local })
+  // },
 
   async get_fits_url ({ rootState }, { base_filename, data_type, reduction_level }) {
     // Get the global configuration for all sites from an api call.

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -65,7 +65,7 @@ const getters = {
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
       if (!cur.header || !cur.header.SMARTSTK || !cur.header.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM
 
-      if (!acc[cur.header.SMARTSTK] || cur.header.SSTKNUM > acc[cur.header.SMARTSTK]) {
+      if (!acc[cur.header.SMARTSTK] || Number(cur.header.SSTKNUM) > Number(acc[cur.header.SMARTSTK])) {
         acc[cur.header.SMARTSTK] = cur.header.SSTKNUM
       }
       return acc

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -151,10 +151,10 @@ const actions = {
      * image, and add it into the 'latest_images' list.
      *
      */
+
   update_new_image ({ commit, state, rootState, dispatch }, new_base_filename) {
     // No need to get the latest if the new image is from a different site.
     const site = rootState.site_config.selected_site
-
     // Get the image's site of origin from the beginning of the filename.
     const image_site_origin = new_base_filename.split('-')[0]
     if (site != image_site_origin) {
@@ -173,6 +173,7 @@ const actions = {
       if (response.data.length == 0) {
         return
       }
+
       const new_image = response.data
       const recent_images = state.recent_images
 
@@ -185,10 +186,12 @@ const actions = {
       }
 
       const new_image_filename = new_image.base_filename
+
       // Find the index of the image we want to update.
       // value will be -1 if it doesn't exist.
       const old_image_index = recent_images.findIndex(image =>
         image.base_filename == new_image_filename)
+
       // If it doesn't already exist, just add it to the array (front).
       if (old_image_index == -1) {
         const updated_recent_images = [new_image, ...recent_images]
@@ -200,6 +203,7 @@ const actions = {
         recent_images[old_image_index] = new_image
         // dispatch('group_images')
       }
+
       // We don't have a toggle implemented yet.
       // But eventually we want one to focus on the new image immediately.
       const incoming_image_takes_focus = false
@@ -345,6 +349,7 @@ const actions = {
     // If a query size is specified, use the old method of retrieving X images
     const querySize = num_images // || 25 (original default);
     url = rootState.api_endpoints.active_api + `/${site}/latest_images/${querySize}`
+
     // If a user is logged in and they want to see only their data,
     // add their id as a query string param for the api call.
     if (state.show_user_data_only && userid) {
@@ -405,6 +410,7 @@ const actions = {
 
     // Query for site's local noon to noon
     url = rootState.api_endpoints.active_api + '/filtered_images'
+
     let queryStart = null
     let queryEnd = null
 
@@ -489,6 +495,7 @@ const actions = {
 
     await axios(body).then(async response => {
       response = response.data
+
       // Empty response:
       if (response.length == 0) {
         dispatch('display_placeholder_image')

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -45,10 +45,6 @@ const state = {
   // TODO: Write an action that will update a user's image list when images are added to their account
   user_images: [],
 
-  // grouped_images: object where images are grouped based on their SMARTSTK value
-  // Before the action group_images, there's an example of what this object looks like after being populated
-  // grouped_images: {},
-
   show_user_data_only: false,
 
   // determines whether 'current_images' is set to show the most recent images with live updates.
@@ -59,7 +55,6 @@ const getters = {
   current_image: state => state.current_image,
   recent_images: state => state.recent_images,
   user_images: state => state.user_images,
-  // grouped_images: state => state.grouped_images,
   recent_images_condensed: state => {
     // First, generate a map of maximum SSTKNUM for each SMARTSTK
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
@@ -107,7 +102,6 @@ const getters = {
 const mutations = {
   setCurrentImage (state, the_current_image) { state.current_image = the_current_image },
   setRecentImages (state, recent_image_list) { state.recent_images = recent_image_list },
-  // setGroupedImages (state, grouped_images) { state.grouped_images = grouped_images },
   setUserImages (state, user_images_list) { state.user_images = user_images_list },
   show_user_data_only (state, val) { state.show_user_data_only = val },
   live_data (state, val) { state.live_data = val },
@@ -197,12 +191,10 @@ const actions = {
       if (old_image_index == -1) {
         const updated_recent_images = [new_image, ...recent_images]
         commit('setRecentImages', updated_recent_images)
-        // dispatch('group_images')
       }
       // Otherwise, replace the old version with the new one we fetched.
       else {
         recent_images[old_image_index] = new_image
-        // dispatch('group_images')
       }
 
       // We don't have a toggle implemented yet.
@@ -271,7 +263,6 @@ const actions = {
       }
 
       commit('setRecentImages', response)
-      // dispatch('group_images')
     }).catch(error => {
       console.warn(error)
     })
@@ -282,63 +273,7 @@ const actions = {
   @param {boolean} user_data_only: whether or not to filter by images
   Taken the active user or not.
 
-  Grouping images as they load and we group them based on their SMARTSTK value
-  After the for loop, the grouped_images_local looks something like this:
-  grouped_images_local: {
-    site: 'tst',
-    imageGroups: {
-      1234: [...grouped images...],
-      5678: [...grouped images...],
-      9012: [...grouped images...]
-    }
-  }
-
   */
-  // group_images ({ commit, state, rootState, dispatch }) {
-  //   const currentSite = rootState.site_config.selected_site
-  //   let grouped_images_local = JSON.parse(JSON.stringify(state.grouped_images))
-  //   if (!grouped_images_local.imageGroups) {
-  //     grouped_images_local.imageGroups = {}
-  //   }
-  //   const recent_images = state.recent_images
-  //   // Resetting grouped_images to an empty object when selecting a different site
-  //   // This prevents accumulation of thumbnails from previous sites selected by user
-  //   if (grouped_images_local.site && grouped_images_local.site !== currentSite) {
-  //     dispatch('reset_grouped_images')
-  //     grouped_images_local = { site: currentSite }
-  //     // If grouped_images_local object doesn't have a key of site (i.e. when page first loads and when user selects
-  //     // a different site), assign the value of currentSite to the new key of site
-  //   } else if (!grouped_images_local.site) {
-  //     grouped_images_local.site = currentSite
-  //   }
-
-  //   for (const img of recent_images) {
-  //     const header = img && img.header
-  //     let SMARTSTK = header && header.SMARTSTK
-  //     // Creating a unique key (i.e. base_filename) for images where SMARTSK is 'no' while also avoiding grouping them as one stack
-  //     // We need this in order to display these images as thumbnails
-  //     if (!SMARTSTK || SMARTSTK === 'no') {
-  //       SMARTSTK = img && img.base_filename
-  //       grouped_images_local.imageGroups[SMARTSTK] = []
-  //       grouped_images_local.imageGroups[SMARTSTK].push(img)
-  //     }
-
-  //     // Grouping images based on SMARTSTK
-  //     if (!grouped_images_local.imageGroups[SMARTSTK]) {
-  //       grouped_images_local.imageGroups[SMARTSTK] = []
-  //       grouped_images_local.imageGroups[SMARTSTK].push(img)
-  //     } else {
-  //       grouped_images_local.imageGroups[SMARTSTK].push(img)
-  //     }
-  //   }
-  //   commit('setGroupedImages', { ...grouped_images_local })
-  // },
-
-  // Resets grouped_images to an empty object
-  // Dispatched when a different site is selected
-  // reset_grouped_images ({ commit }) {
-  //   commit('setGroupedImages', {})
-  // },
 
   async load_latest_x_images ({ dispatch, commit, state, rootState }, num_images) {
     // Old method of loading only a certain amount of images
@@ -375,7 +310,6 @@ const actions = {
 
       commit('setCurrentImage', response[0])
       commit('setRecentImages', response)
-      // dispatch('group_images')
     }).catch(error => {
       console.error(error)
     })
@@ -505,7 +439,6 @@ const actions = {
 
       commit('setCurrentImage', response[0])
       commit('setRecentImages', response)
-      // dispatch('group_images')
     }).catch(error => {
       console.error(error)
     })
@@ -582,7 +515,6 @@ const actions = {
     }
     commit('setRecentImages', [placeholder_image])
     commit('setCurrentImage', placeholder_image)
-    // dispatch('reset_grouped_images')
   },
 
   // Set this_image as the current displayed image
@@ -620,11 +552,6 @@ const actions = {
     const first_image = state.recent_images[state.recent_images.length - 1]
     commit('setCurrentImage', first_image)
   },
-
-  // set_grouped_images ({ commit, state }) {
-  //   const grouped_images_local = state.grouped_images
-  //   commit('setGroupedImages', { ...grouped_images_local })
-  // },
 
   async get_fits_url ({ rootState }, { base_filename, data_type, reduction_level }) {
     // Get the global configuration for all sites from an api call.

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -173,16 +173,12 @@ const actions = {
 
       // If it doesn't already exist, just add it to the array (front).
       if (old_image_index == -1) {
-        console.log('old')
         const updated_recent_images = [new_image, ...recent_images]
         commit('setRecentImages', updated_recent_images)
-        dispatch('group_images')
       }
       // Otherwise, replace the old version with the new one we fetched.
       else {
-        console.log('new image')
         recent_images[old_image_index] = new_image
-        dispatch('group_images')
       }
 
       // We don't have a toggle implemented yet.

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -55,6 +55,7 @@ const getters = {
   current_image: state => state.current_image,
   recent_images: state => state.recent_images,
   user_images: state => state.user_images,
+  // Uses recent_images but removes any intermediate smartstack frames, so you only see the latest version of each smart stack
   recent_images_condensed: state => {
     // First, generate a map of maximum SSTKNUM for each SMARTSTK
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -153,7 +153,6 @@ const actions = {
         return
       }
       const new_image = response.data
-      console.log('new_image,', new_image)
       const recent_images = state.recent_images
 
       // Don't show add the image if the user is requesting their data
@@ -165,12 +164,10 @@ const actions = {
       }
 
       const new_image_filename = new_image.base_filename
-
       // Find the index of the image we want to update.
       // value will be -1 if it doesn't exist.
       const old_image_index = recent_images.findIndex(image =>
         image.base_filename == new_image_filename)
-
       // If it doesn't already exist, just add it to the array (front).
       if (old_image_index == -1) {
         const updated_recent_images = [new_image, ...recent_images]
@@ -182,7 +179,6 @@ const actions = {
         recent_images[old_image_index] = new_image
         dispatch('group_images')
       }
-
       // We don't have a toggle implemented yet.
       // But eventually we want one to focus on the new image immediately.
       const incoming_image_takes_focus = false
@@ -278,13 +274,11 @@ const actions = {
       grouped_images_local.imageGroups = {}
     }
     const recent_images = state.recent_images
-
     // Resetting grouped_images to an empty object when selecting a different site
     // This prevents accumulation of thumbnails from previous sites selected by user
     if (grouped_images_local.site && grouped_images_local.site !== currentSite) {
       dispatch('reset_grouped_images')
       grouped_images_local = { site: currentSite }
-
       // If grouped_images_local object doesn't have a key of site (i.e. when page first loads and when user selects
       // a different site), assign the value of currentSite to the new key of site
     } else if (!grouped_images_local.site) {
@@ -296,7 +290,7 @@ const actions = {
       let SMARTSTK = header && header.SMARTSTK
       // Creating a unique key (i.e. base_filename) for images where SMARTSK is 'no' while also avoiding grouping them as one stack
       // We need this in order to display these images as thumbnails
-      if (SMARTSTK === 'no') {
+      if (!SMARTSTK || SMARTSTK === 'no') {
         SMARTSTK = img && img.base_filename
         grouped_images_local.imageGroups[SMARTSTK] = []
         grouped_images_local.imageGroups[SMARTSTK].push(img)
@@ -311,6 +305,8 @@ const actions = {
       }
     }
     commit('setGroupedImages', { ...grouped_images_local })
+    console.log('grouped images local,', grouped_images_local)
+    console.log('grouped images state,', state.grouped_images)
   },
 
   // Resets grouped_images to an empty object
@@ -499,7 +495,7 @@ const actions = {
       axios.get(url).then(response => {
         // Handle case if no info image exists
         if (response.status == 204) {
-          commit('setInfoImage', { info_image: { jpg_url: '' }, channel }) // reset to default empty value 
+          commit('setInfoImage', { info_image: { jpg_url: '' }, channel }) // reset to default empty value
           return
         }
         // Only update the current image if currently set to the old info image


### PR DESCRIPTION
### FEATURE UPDATE: Update Image Grouping and Display


### DESCRIPTION
**Background:**
After having grouped images, more details [here](https://github.com/LCOGT/ptr_ui/pull/96#issue-1897475981), @wrosing noticed that a couple of issues emerged. First, thumbnails were taking a really long time to load. And second, the ThumbnailRow component was not updating with new images as they were coming. Only after the user would refresh the page, would the new images show up. Additionally, sometimes the images would show up at the very end of the ThumbnailRow rather than at the beginning. 


**Implementation:**
With the extensive help and advice of @timbeccue, I learned that Vue is not as reactive to `group_images` because of its data structures. Instead, it's best to store images in an array so that the UI can re-render when the state has updated (i.e. when new images come). This new implementation can be found on lines 63-72 of `images.js`. 


 ```   recent_images_condensed: state => {
    // First, generate a map of maximum SSTKNUM for each SMARTSTK
    const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
      if (!cur.header || !cur.header.SMARTSTK || !cur.header.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM

      const num = parseInt(cur.header.SSTKNUM) // convert string to number
      if (!acc[cur.header.SMARTSTK] || num > acc[cur.header.SMARTSTK]) {
        acc[cur.header.SMARTSTK] = num
      }
      return acc
    }, {})
    const filteredArr = state.recent_images.filter(el => {
      if (!el.header || !el.header.SMARTSTK || !el.header.SSTKNUM) return true
      return el.header.SSTKNUM >= maxSSTKNUMs[el.header.SMARTSTK]
    })
    return filteredArr
}
```

This new implementation, written by @timbeccue,  goes as follows:

1. First, it takes the existing array of `recent_images` and with the `reduce` method, it creates a map (`maxSSTKNUMs`) where the key is `SMARTSTK` and the value is the greatest `SSTKNUM` found in the `recent_images` array
2. Then, the it checks if the current image has a `header`, a `SMARTSTK`, or a `SSTKNUM` (stack number). If it doesn't have any, then we return the acc as is. 
3. Next, for each unique `SMARTSTK` in the array of image objects, it finds the max value of `SSTKNUM`. If the current image has a `SMARTSTK` value that is not yet in the acc object OR if the `SSTKNUM` value (parsed to an integer) is greater than the currently one stored in acc for that existing `SMARTSTK`, it updates the acc with the new maximum `SSTKNUM` for that `SMARTSTK`.
4. It then returns the acc object to be used in the next iteration
5. Then it filters the `recent_images` array to include items that either don't have a `header`, `SMARTSTK`, or `SSTKNUM` OR have the maximum `SSTKNUM` for the `SMARTSTK` associated with it. 
6. Finally, it returns the filtered array `filteredArr`



**Updated Features:**

1. Reduced Thumbnail Count: Only the most recent image from each smart stack is displayed in the ThumbnailRow component. Thus, reducing significantly the number of thumbnail images displayed. This remains true, however, the implementation has now changed, as mentioned above
2. Updating Images: Because images are now stored in an array, the UI is now reacting to the updates. As images are stored in the state, it's accurately reflected on the UI and shown at the beginning of the ThumbnailRow carousel.


### Visuals:

**Before taking an image**


<img width="1728" alt="Screenshot 2023-09-27 at 12 10 25 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/bdf76f14-b69e-4ce1-b15e-d90881fa34cb">






**After taking an image and without having to refresh the site**


<img width="1728" alt="Screenshot 2023-09-27 at 12 11 08 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/02c9baa2-c287-42c6-96b7-4864c70c7e01">
