### PR TITLE
Remove redundant api calls for fits headers

### DIFF
--- a/src/components/ImageDisplay/FitsHeaderModal.vue
+++ b/src/components/ImageDisplay/FitsHeaderModal.vue
@@ -53,7 +53,6 @@
             :data="fitsHeaderTable"
             :columns="columns"
             style="width: auto; flex: 0"
-            :loading="headerIsLoading"
           />
         </div>
       </div>
@@ -76,9 +75,7 @@ export default {
   },
   data () {
     return {
-      fitsHeader: {},
       showFitsHeaderModal: false,
-      headerIsLoading: false,
       columns: [
         {
           field: 'key',
@@ -94,41 +91,22 @@ export default {
       ]
     }
   },
-  watch: {
-    image () {
-      if (this.showFitsHeaderModal) {
-        this.refreshFitsHeader()
-      }
-    }
-  },
   computed: {
     fitsHeaderTable () {
       const tableData = []
-      for (const property in this.fitsHeader) {
+      for (const property in this.image.header) {
         tableData.push({
           key: property.toLowerCase(),
-          val: this.fitsHeader[property]
+          val: this.image.header[property]
         })
       }
       return tableData
     }
   },
   methods: {
-    refreshFitsHeader () {
-      this.fitsHeader = {}
-      this.headerIsLoading = true
-      this.$store.dispatch('images/loadCurrentImageFitsHeader').then(header => {
-        this.fitsHeader = header
-      }).finally(() => {
-        this.headerIsLoading = false
-      })
-    },
     showFitsHeader () {
-      this.refreshFitsHeader()
       this.showFitsHeaderModal = true
     }
   }
 }
 </script>
-<style lang="scss" scoped>
-</style>


### PR DESCRIPTION
Previously, accessing the fits header for an image required an api call to fetch it. Since header data is now included when images are loaded, we don't need to make a separate call each time we want to access a new image's header info.

This change removes the api calls from the fits header modal component, and uses the header data that is already included in the image's metadata object. 