### PR TITLE
Feature/update mosaic fields

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -369,6 +369,7 @@
             >
               <b-input
                 v-model="exposures[n-1].width"
+                :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
@@ -383,6 +384,7 @@
             >
               <b-input
                 v-model="exposures[n-1].height"
+                :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
@@ -1191,9 +1193,9 @@ export default {
     },
     getSymbol (zoom) {
       if (zoom === 'Mosaic deg.') {
-        console.log('data max,', zoom + '°')
-        return '°'
-      } else if (zoom === 'Mosaic arcmin.') return "'"
+        console.log('deg')
+        return 'degree-input'
+      } else if (zoom === 'Mosaic arcmin.') return 'arcmin-input'
       return '' // return an empty string if there is no match
     }
   },
@@ -1334,5 +1336,24 @@ export default {
     flex-direction: row;
     gap: 1em;
     margin-bottom: 1em;
+}
+.degree-input::after {
+  content: '°';
+  position: absolute;
+  top: 50%;
+  left: 40%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: white;
+}
+
+.arcmin-input::after {
+  content: "'";
+  position: absolute;
+  top: 50%;
+  left: 40%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: white;
 }
 </style>

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1193,7 +1193,6 @@ export default {
     },
     getSymbol (zoom) {
       if (zoom === 'Mosaic deg.') {
-        console.log('test')
         return 'degree-input'
       } else if (zoom === 'Mosaic arcmin.') return 'arcmin-input'
       return '' // return an empty string if there is no match

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1193,6 +1193,7 @@ export default {
     },
     getSymbol (zoom) {
       if (zoom === 'Mosaic deg.') {
+        console.log('test')
         return 'degree-input'
       } else if (zoom === 'Mosaic arcmin.') return 'arcmin-input'
       return '' // return an empty string if there is no match

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -399,6 +399,7 @@
             >
               <b-input
                 v-model="exposures[n-1].angle"
+                :class="addSymbol(exposures[n-1].angle)"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
@@ -406,6 +407,7 @@
                 max="90.0"
                 step="5"
               />
+              <template v-slot:append>°</template>
             </b-field>
             <div />
           </div>
@@ -1196,6 +1198,11 @@ export default {
         return 'degree-input'
       } else if (zoom === 'Mosaic arcmin.') return 'arcmin-input'
       return '' // return an empty string if there is no match
+    },
+    addSymbol (angle) {
+      if (angle) {
+        return 'angle-input'
+      }
     }
   },
   computed: {
@@ -1348,6 +1355,16 @@ export default {
 
 .arcmin-input::after {
   content: "'";
+  position: absolute;
+  top: 50%;
+  left: 40%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: white;
+}
+
+.angle-input::after {
+  content: '°';
   position: absolute;
   top: 50%;
   left: 40%;

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -407,7 +407,6 @@
                 max="90.0"
                 step="5"
               />
-              <template v-slot:append>°</template>
             </b-field>
             <div />
           </div>

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1191,7 +1191,7 @@ export default {
     },
     getSymbol (zoom) {
       if (zoom === 'Mosaic deg.') {
-        console.log('zoom deg')
+        console.log('data max,', zoom + '°')
         return '°'
       } else if (zoom === 'Mosaic arcmin.') return "'"
       return '' // return an empty string if there is no match


### PR DESCRIPTION
### UPDATE: Added two methods to be able to add symbols to the width, height, and angle mosaic fields

**Implementation**
The first method, `getSymbol`, gets the appropriate symbol depending on whether `Mosaic arcmin.` or `Mosaic deg.` is selected under the `Zoom` field. If anything else is selected, then no symbol is added. The symbol is added by dynamically changing the classes of `Width` and `Height`. The symbol is added via CSS by changing `content` to either a ° or a '

The second method, `addSymbol`, adds a static class to the `Angle` field. We can't just add a class to the `Angle` input because if we add the content of ° to the class, then the whole input disappears. For this reason, this method simply returns 'angle-input' and becomes the class of the field. This way we can append the symbol inside the box and expect normal behavior. 

**Notes**
I tried adding a span and other html elements, but that just renders the symbol outside of the box. I believe this is related to buefy but in the meantime, this seems to work.