### PR TITLE
Feature/update grouped images

### DIFF
--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -169,6 +169,7 @@ const actions = {
       if (response.data.length == 0) {
         return
       }
+      console.log('api: ', apiName + path)
 
       const new_image = response.data
       const recent_images = state.recent_images
@@ -196,6 +197,15 @@ const actions = {
       // Otherwise, replace the old version with the new one we fetched.
       else {
         recent_images[old_image_index] = new_image
+      }
+      // Reassigning value of current_image to new_image
+      // If a user takes smart stack photos and they select the image as it's updating,
+      // then the selected image (i.e. the thumbnail with the surrounding yellow border) keeps the yellow border
+      let current_image = state.current_image
+      const current_image_SMARTSTK = current_image.header && current_image.header.SMARTSTK
+      const new_image_SMARTSTK = new_image.header && new_image.header.SMARTSTK
+      if (current_image_SMARTSTK !== 'no' && current_image_SMARTSTK === new_image_SMARTSTK) {
+        current_image = new_image
       }
 
       // We don't have a toggle implemented yet.

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -169,7 +169,6 @@ const actions = {
       if (response.data.length == 0) {
         return
       }
-      console.log('api: ', apiName + path)
 
       const new_image = response.data
       const recent_images = state.recent_images
@@ -204,7 +203,7 @@ const actions = {
       let current_image = state.current_image
       const current_image_SMARTSTK = current_image.header && current_image.header.SMARTSTK
       const new_image_SMARTSTK = new_image.header && new_image.header.SMARTSTK
-      if (current_image_SMARTSTK !== 'no' && current_image_SMARTSTK === new_image_SMARTSTK) {
+      if (current_image_SMARTSTK && current_image_SMARTSTK !== 'no' && current_image_SMARTSTK === new_image_SMARTSTK) {
         current_image = new_image
       }
 


### PR DESCRIPTION
### FEATURE FIX UPDATE: Added exposure fields under Projects tab with conditional adjustments

### DESCRIPTION


**Background:**
After successfully having grouped images and only displaying the latest one from each smart stack (if it was a part of a smart stack), a new issue arose. @wrosing noticed that when he was taking smart stack photos, the first one would come in just fine. But if he selected the new image of the smart stack and it was (e.g.) 1 of 10 and then it updated to 2 of 10, the yellow border that surrounds the selected image thumbnail would disappear and some other erratic behavior would occur. 

In the ThumbnailRow component, we assign the class of `selected_thumbnail` if `item.image_id` is equal to `selected_image`. This class creates the yellow border.  However, because the new updated image's `image_id` from the smart stack was not the same value as `selected_image`, the class was no longer assigned and therefore, the surrounding yellow border would disappear. 



**Implementation:**

In `images.js` under the `update_new_image` action, we are now reassigning the value of `current_image` to `new_image`. This happens only if certain conditions are met: 

1. If `current_image` has a `SMARTSTK` that's not equal to 'no'.  AND
2. If `new_image` has a `SMARTSTK` and is equal to `current_image`'s `SMARTSTK`


**Features Fixes :**

After having implemented changes to the ThumbnailRow component so that images could be grouped (details [here](https://github.com/LCOGT/ptr_ui/pull/100#issue-1916185027)), the new issue of the selected thumbnail not having a yellow border if it was a new image and a part of a smart stack arose. Reassigning the value of `new_image` to `current_image` should fix this feature and it should all behave as expected.

**Important Note:**
This has not been 100% tested because I cannot take smart stack photos unless it's nighttime. I will wait for @wrosing's feedback, but I believe this should fix all issues related to updating images. 


### VISUALS
No visuals yet, but will add them tonight if I'm able to test with smart stack :-)