### PR TITLE
Feature: Updated mosaic field steps

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -365,10 +365,10 @@
             </b-field>
             <b-field
               :label="n==1 ? 'Width' : ''"
-              style="width: 80px;"
+              style="width: 150px;"
             >
-              <b-input
-                v-model="exposures[n-1].width"
+              <b-numberinput
+                :value="Number(exposures[n-1].width)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
@@ -376,14 +376,16 @@
                 :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minWidthDegrees * degreesToArcminutes : minWidthDegrees"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidthDegrees * degreesToArcminutes : maxWidthDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
+                min-step="0.001"
+                @input="val => exposures[n-1].width = val"
               />
             </b-field>
             <b-field
               :label="n==1 ? 'Height' : ''"
-              style="width: 80px;"
+              style="width: 150px;"
             >
-              <b-input
-                v-model="exposures[n-1].height"
+              <b-numberinput
+                :value="Number(exposures[n-1].height)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
@@ -391,21 +393,25 @@
                 :min="exposures[n-1].zoom === 'Mosaic arcmin.' ? minHeightDegrees * degreesToArcminutes : minHeightDegrees"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeightDegrees * degreesToArcminutes : maxHeightDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
+                min-step="0.001"
+                @input="val => exposures[n-1].height = val"
               />
             </b-field>
             <b-field
               :label="n==1 ? 'Angle' : ''"
-              style="width: 80px;"
+              style="width: 150px;"
             >
-              <b-input
-                v-model="exposures[n-1].angle"
+              <b-numberinput
+                :value="Number(exposures[n-1].angle)"
                 class="angle-input"
                 size="is-small"
                 :disabled="!exposures[n-1].active"
                 type="number"
-                min="-90.0"
-                max="90.0"
-                step="5"
+                :min="-90.0"
+                :max="90.0"
+                :step="5"
+                min-step="0.001"
+                @input="val => exposures[n-1].angle = val"
               />
             </b-field>
             <div />
@@ -874,6 +880,7 @@ export default {
       maxHeightDegrees: 4.5,
       degreesToArcminutes: 60,
       conditionalStep: 0.1,
+      keyDownTime: null,
       site: this.sitecode,
       warn: {
         project_name: false,
@@ -1337,33 +1344,54 @@ export default {
     gap: 1em;
     margin-bottom: 1em;
 }
+.b-numberinput {
+    position: relative;
+}
 .degree-input::after {
-  content: '°';
-  position: absolute;
-  top: 50%;
-  left: 40%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: white;
+    content: "°";
+    position: absolute;
+    right: 35%;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    z-index: 1;
 }
-
 .arcmin-input::after {
-  content: "'";
-  position: absolute;
-  top: 50%;
-  left: 40%;
-  transform: translateY(-50%);
-  pointer-events: none;
-  color: white;
+    content: "'";
+    position: absolute;
+    right: 35%;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    z-index: 1;
 }
-
 .angle-input::after {
   content: '°';
   position: absolute;
   top: 50%;
-  left: 40%;
+  left: 63%;
   transform: translateY(-50%);
   pointer-events: none;
   color: white;
+  z-index: 1;
+}
+</style>
+
+<style>
+/* Global styles */
+.b-numberinput {
+    display: flex;
+    align-items: center;
+    gap: 0px;
+}
+.b-numberinput button {
+    margin: 0 !important;
+    padding: 0 4px;
+    height: 24px;
+    font-size: 0.8rem;
+}
+
+.b-numberinput input[type="number"] {
+    margin: 0 !important;
 }
 </style>

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -368,6 +368,7 @@
               style="width: 150px;"
             >
               <b-numberinput
+                :v-model="exposures[n-1].width"
                 :value="Number(exposures[n-1].width)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
@@ -377,7 +378,6 @@
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidthDegrees * degreesToArcminutes : maxWidthDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
                 min-step="0.001"
-                @input="val => exposures[n-1].width = val"
               />
             </b-field>
             <b-field
@@ -385,6 +385,7 @@
               style="width: 150px;"
             >
               <b-numberinput
+                :v-model="exposures[n-1].height"
                 :value="Number(exposures[n-1].height)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
@@ -394,7 +395,6 @@
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeightDegrees * degreesToArcminutes : maxHeightDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
                 min-step="0.001"
-                @input="val => exposures[n-1].height = val"
               />
             </b-field>
             <b-field
@@ -402,6 +402,7 @@
               style="width: 150px;"
             >
               <b-numberinput
+                :v-model="exposures[n-1].angle"
                 :value="Number(exposures[n-1].angle)"
                 class="angle-input"
                 size="is-small"
@@ -411,7 +412,6 @@
                 :max="90.0"
                 :step="5"
                 min-step="0.001"
-                @input="val => exposures[n-1].angle = val"
               />
             </b-field>
             <div />


### PR DESCRIPTION
### FEATURE UPDATE: User can now manually input to the third decimal space of width, height, and angle mosaic fields

### DESCRIPTION


**Background:**
@wrosing requested that under the `Projects` > `Exposures` tabs, to add a few fields (details [here](https://github.com/LCOGT/ptr_ui/pull/99#issue-1907626586)). Wayne requested for users to be able to be able to manually write in to the thousandth decimal place, but to keep the step as it was (i.e. 0.1 for mosaic deg and 1 for mosaic arcmin & 5 for angle). The solution to this problem was to change the type of element. 

**Implementation:**
I changed the type of element that these fields were. Before they were `b-input` (an element from buefy) and now they're `b-numberinput`. The reason for this is because you can't have a step of 0.1 and then have the user manually input anything non-divisible by 0.1. However, with `b-numberinput` you can add a `min-step`. This allows for the user to manually add decimals to the third place. Along with this change, I had to convert the input value to a number because it was being read as a string. This was done by adding `:value="Number(exposures[n-1].field-name)"` to each field.

I also had to change the SCSS styling a little bit and added a `style` that wasn't scoped cause that was preventing a lot of it from displaying as I was intending. And changed the size of the `b-field`s.


### Visuals:


**Image of the Projects tab with the new ability of adding a thousandth number**
<img width="1728" alt="Screenshot 2023-10-09 at 6 19 25 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/3860cd48-db24-4b1c-bc1f-0b515243089f">
