### PR TITLE
Feature/owm report mirrored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19092,9 +19092,14 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.7.1.tgz",
       "integrity": "sha512-Ktvp6Bt6ApYj35MuxTClu+9Lpukcgl3Z/0o4PU12+Z4jU6lyOMzos0k6zGT5xrukAkGM1VV3EYNwz1TnHPhgFA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "shvl": "^2.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^2.0.0",
+        "vuex": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/vuex-persistedstate/node_modules/deepmerge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vue-material-design-icons": "^4.6.0",
         "vue-router": "^3.2.0",
         "vuex": "^3.4.0",
-        "vuex-persistedstate": "^2.7.1",
+        "vuex-persistedstate": "^4.1.0",
         "ws": "^7.3.0"
       },
       "devDependencies": {
@@ -17016,9 +17016,10 @@
       "dev": true
     },
     "node_modules/shvl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.0.tgz",
-      "integrity": "sha512-WbpzSvI5XgVGJ3A4ySGe8hBxj0JgJktfnoLhhJmvITDdK21WPVWwgG8GPlYEh4xqdti3Ff7PJ5G0QrRAjNS0Ig=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.3.tgz",
+      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==",
+      "deprecated": "older versions vulnerable to prototype pollution"
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -19089,23 +19090,22 @@
       "integrity": "sha512-ajtqwEW/QhnrBZQsZxCLHThZZaa+Db45c92Asf46ZDXu6uHXgbfVuBaJ4gzD2r4UX0oMJHstFwd2r2HM4l8umg=="
     },
     "node_modules/vuex-persistedstate": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.7.1.tgz",
-      "integrity": "sha512-Ktvp6Bt6ApYj35MuxTClu+9Lpukcgl3Z/0o4PU12+Z4jU6lyOMzos0k6zGT5xrukAkGM1VV3EYNwz1TnHPhgFA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz",
+      "integrity": "sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "deepmerge": "^4.2.2",
-        "shvl": "^2.0.0"
+        "shvl": "^2.0.3"
       },
       "peerDependencies": {
-        "vue": "^2.0.0",
-        "vuex": "^2.0.0 || ^3.0.0"
+        "vuex": "^3.0 || ^4.0.0-rc"
       }
     },
     "node_modules/vuex-persistedstate/node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -34597,9 +34597,9 @@
       "dev": true
     },
     "shvl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.0.tgz",
-      "integrity": "sha512-WbpzSvI5XgVGJ3A4ySGe8hBxj0JgJktfnoLhhJmvITDdK21WPVWwgG8GPlYEh4xqdti3Ff7PJ5G0QrRAjNS0Ig=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/shvl/-/shvl-2.0.3.tgz",
+      "integrity": "sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw=="
     },
     "side-channel": {
       "version": "1.0.4",
@@ -36371,18 +36371,18 @@
       "integrity": "sha512-ajtqwEW/QhnrBZQsZxCLHThZZaa+Db45c92Asf46ZDXu6uHXgbfVuBaJ4gzD2r4UX0oMJHstFwd2r2HM4l8umg=="
     },
     "vuex-persistedstate": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-2.7.1.tgz",
-      "integrity": "sha512-Ktvp6Bt6ApYj35MuxTClu+9Lpukcgl3Z/0o4PU12+Z4jU6lyOMzos0k6zGT5xrukAkGM1VV3EYNwz1TnHPhgFA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz",
+      "integrity": "sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==",
       "requires": {
         "deepmerge": "^4.2.2",
-        "shvl": "^2.0.0"
+        "shvl": "^2.0.3"
       },
       "dependencies": {
         "deepmerge": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+          "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vue-material-design-icons": "^4.6.0",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0",
-    "vuex-persistedstate": "^2.7.1",
+    "vuex-persistedstate": "^4.1.0",
     "ws": "^7.3.0"
   },
   "devDependencies": {

--- a/src/components/InstrumentControls/Enclosure.vue
+++ b/src/components/InstrumentControls/Enclosure.vue
@@ -379,17 +379,7 @@
 
     <br>
 
-    <div style="margin-bottom: 1em;">
-      OWM Report
-      <pre>{{ owm_report }}</pre>
-    </div>
-
-    <div style="margin-bottom: 1em;">
-      <b-button @click="showOwmStatus">(alternate method) show OWM Status</b-button>
-    </div>
-    <b-modal v-model="owmModalVisible">
-      <pre>{{ owm_report }}</pre>
-    </b-modal>
+    <OWMReport />
 
     <div
       class="status-toggle-bar"
@@ -414,15 +404,16 @@ import { user_mixin } from '../../mixins/user_mixin'
 import CommandButton from '@/components/FormElements/CommandButton'
 import SimpleDeviceStatus from '@/components/status/SimpleDeviceStatus'
 import StatusVal from '@/components/status/StatusVal'
+import OWMReport from '@/components/status/OWMReport'
 import { mapGetters } from 'vuex'
-import axios from 'axios'
 export default {
   name: 'Enclosure',
   mixins: [commands_mixin, user_mixin],
   components: {
     CommandButton,
     StatusVal,
-    SimpleDeviceStatus
+    SimpleDeviceStatus,
+    OWMReport
   },
   data () {
     return {
@@ -453,22 +444,8 @@ export default {
       skyTempLimitDangerLevel: 90,
       lowestAmbientTemp: '',
       highestAmbientTemp: '',
-
-      owmModalVisible: false,
-      owm_report: '...loading...'
     }
   },
-
-  mounted () {
-    this.getOwmReport()
-  },
-  watch: {
-    '$route.params.sitecode' () {
-      this.owm_report = '...loading...'
-      this.getOwmReport()
-    }
-  },
-
   methods: {
     enclosure_force_roof_state (val) {
       return this.wema_base_command('enclosure', 'force_roof_state', '',
@@ -477,17 +454,6 @@ export default {
         }
       )
     },
-    getOwmReport () {
-      const endpoint = this.$store.state.api_endpoints.status_endpoint + '/' + this.wema_name + '/owm_report'
-      axios.get(endpoint).then(response => {
-        this.owm_report = JSON.parse(response.data.status.owm_report)
-      }).catch(() => {
-        this.owm_report = 'OWM report unavailable'
-      })
-    },
-    showOwmStatus () {
-      this.owmModalVisible = true
-    }
   },
 
   computed: {

--- a/src/components/sitepages/SiteHome.vue
+++ b/src/components/sitepages/SiteHome.vue
@@ -54,7 +54,6 @@
     <div style="height: 2em;" />
 
     <OWMReport v-if="userIsAdmin" />
-
   </div>
 </template>
 
@@ -72,7 +71,7 @@ export default {
   components: {
     SiteEventsModal,
     OWMReport
-},
+  },
   computed: {
     ...mapGetters('site_config', [
       'site_latitude',

--- a/src/components/sitepages/SiteHome.vue
+++ b/src/components/sitepages/SiteHome.vue
@@ -52,6 +52,9 @@
     </div>
 
     <div style="height: 2em;" />
+
+    <OWMReport />
+
   </div>
 </template>
 
@@ -60,14 +63,16 @@ import { mapGetters } from 'vuex'
 import { commands_mixin } from '../../mixins/commands_mixin'
 import { user_mixin } from '../../mixins/user_mixin'
 import SiteEventsModal from '@/components/SiteEventsModal'
+import OWMReport from '@/components/status/OWMReport'
 
 export default {
   name: 'SiteHome',
   props: ['sitecode'],
   mixins: [commands_mixin, user_mixin],
   components: {
-    SiteEventsModal
-  },
+    SiteEventsModal,
+    OWMReport
+},
   computed: {
     ...mapGetters('site_config', [
       'site_latitude',

--- a/src/components/sitepages/SiteHome.vue
+++ b/src/components/sitepages/SiteHome.vue
@@ -53,7 +53,7 @@
 
     <div style="height: 2em;" />
 
-    <OWMReport />
+    <OWMReport v-if="userIsAdmin" />
 
   </div>
 </template>
@@ -78,7 +78,10 @@ export default {
       'site_latitude',
       'site_longitude',
       'site_name'
-    ])
+    ]),
+    userIsAdmin () {
+      return this.$store.state.user_data.userIsAdmin
+    }
   }
 }
 

--- a/src/components/status/OWMReport.vue
+++ b/src/components/status/OWMReport.vue
@@ -15,8 +15,8 @@
 </template>
 
 <script>
-import axios from 'axios'
 import { mapGetters } from 'vuex'
+import NightLog from '../NightLog.vue'
 
 export default {
   name: 'OWMReport',
@@ -41,21 +41,10 @@ export default {
     }
   },
   methods: {
-    // TODO: Need to cache this
     getOwmReport () {
-      // call to cache to check if we have the report already
-
-      // load report from store if we do
-
-      // call the api if we don't
-      const endpoint = this.$store.state.api_endpoints.status_endpoint + '/' + this.wema_name + '/owm_report'
-      axios.get(endpoint).then(response => {
-        // cache the report in store for only 1 hour
-
-        this.owmReport = JSON.parse(response.data.status.owm_report)
-      }).catch(() => {
-        this.owmReport = 'OWM report unavailable'
-      })
+      this.$store.dispatch('sitestatus/getLatestOwmReport').then((res) => {
+        this.owmReport = this.$store.getters['sitestatus/owmReport']
+      })      
     },
     showOwmStatus () {
       this.owmModalVisible = true

--- a/src/components/status/OWMReport.vue
+++ b/src/components/status/OWMReport.vue
@@ -6,7 +6,9 @@
     </div>
 
     <div style="margin-bottom: 1em;">
-      <b-button @click="showOwmStatus">(alternate method) show OWM Status</b-button>
+      <b-button @click="showOwmStatus">
+        (alternate method) show OWM Status
+      </b-button>
     </div>
     <b-modal v-model="owmModalVisible">
       <pre>{{ owmReport }}</pre>
@@ -16,7 +18,6 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import NightLog from '../NightLog.vue'
 
 export default {
   name: 'OWMReport',
@@ -44,7 +45,7 @@ export default {
     getOwmReport () {
       this.$store.dispatch('sitestatus/getLatestOwmReport').then((res) => {
         this.owmReport = this.$store.getters['sitestatus/owmReport']
-      })      
+      })
     },
     showOwmStatus () {
       this.owmModalVisible = true

--- a/src/components/status/OWMReport.vue
+++ b/src/components/status/OWMReport.vue
@@ -43,8 +43,15 @@ export default {
   methods: {
     // TODO: Need to cache this
     getOwmReport () {
+      // call to cache to check if we have the report already
+
+      // load report from store if we do
+
+      // call the api if we don't
       const endpoint = this.$store.state.api_endpoints.status_endpoint + '/' + this.wema_name + '/owm_report'
       axios.get(endpoint).then(response => {
+        // cache the report in store for only 1 hour
+
         this.owmReport = JSON.parse(response.data.status.owm_report)
       }).catch(() => {
         this.owmReport = 'OWM report unavailable'

--- a/src/components/status/OWMReport.vue
+++ b/src/components/status/OWMReport.vue
@@ -1,0 +1,58 @@
+<template>
+  <div>
+    <div style="margin-bottom: 1em;">
+      OWM Report
+      <pre>{{ owmReport }}</pre>
+    </div>
+
+    <div style="margin-bottom: 1em;">
+      <b-button @click="showOwmStatus">(alternate method) show OWM Status</b-button>
+    </div>
+    <b-modal v-model="owmModalVisible">
+      <pre>{{ owmReport }}</pre>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import { mapGetters } from 'vuex'
+
+export default {
+  name: 'OWMReport',
+  data () {
+    return {
+      owmModalVisible: false,
+      owmReport: '...loading...'
+    }
+  },
+  computed: {
+    ...mapGetters('site_config', [
+      'wema_name'
+    ])
+  },
+  mounted () {
+    this.getOwmReport()
+  },
+  watch: {
+    '$route.params.sitecode' () {
+      this.owmReport = '...loading...'
+      this.getOwmReport()
+    }
+  },
+  methods: {
+    // TODO: Need to cache this
+    getOwmReport () {
+      const endpoint = this.$store.state.api_endpoints.status_endpoint + '/' + this.wema_name + '/owm_report'
+      axios.get(endpoint).then(response => {
+        this.owmReport = JSON.parse(response.data.status.owm_report)
+      }).catch(() => {
+        this.owmReport = 'OWM report unavailable'
+      })
+    },
+    showOwmStatus () {
+      this.owmModalVisible = true
+    }
+  }
+}
+</script>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,9 +20,12 @@ import createPersistedState from 'vuex-persistedstate'
 
 Vue.use(Vuex)
 
-// Todo: research more into other state variables could benefit from a persisted state and seperate into a module
+/**
+ * Todo: research more into other state variables could benefit from a persisted
+ * state and seperate into a module persisting this state to save api calls when page refreshes
+ */
 const dataState = createPersistedState({
-  paths: ['sitestatus.owmReport']
+  paths: ['sitestatus.siteOwmReports']
 })
 
 const store = new Vuex.Store({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,7 @@ import createPersistedState from 'vuex-persistedstate'
 
 Vue.use(Vuex)
 
+// Todo: research more into other state variables could benefit from a persisted state and seperate into a module
 const dataState = createPersistedState({
   paths: ['sitestatus.owmReport']
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -16,12 +16,18 @@ import user_interface from './modules/user_interface'
 import uiSync from './modules/uiSync'
 
 import UiSyncPlugin from './plugins/ui_sync'
+import createPersistedState from 'vuex-persistedstate'
 
 Vue.use(Vuex)
 
+const dataState = createPersistedState({
+  paths: ['sitestatus.owmReport']
+})
+
 const store = new Vuex.Store({
   plugins: [
-    UiSyncPlugin
+    UiSyncPlugin,
+    dataState
   ],
   modules: {
     site_config,

--- a/src/store/modules/sitestatus/index.js
+++ b/src/store/modules/sitestatus/index.js
@@ -53,7 +53,7 @@ const getters = {
   now: state => state.now,
   owmReport: (state, getters, rootState, rootGetters) => {
     const wema_name = rootGetters['site_config/wema_name']
-    if(wema_name){
+    if (wema_name) {
       return JSON.parse(state.owmReport.find(owmReport => owmReport.wema_name === wema_name).report)
     }
   },
@@ -273,12 +273,12 @@ const mutations = {
     state.obs_settings = status.obs_settings
   },
 
-  new_owmReport(state, newOwmReport){
+  new_owmReport (state, newOwmReport) {
     // only keep the most up to date report per site
-    state.owmReport= state.owmReport.filter(function(reportObj){
+    state.owmReport = state.owmReport.filter(function (reportObj) {
       return reportObj.wema_name !== newOwmReport.wema_name
     })
-    state.owmReport.push( newOwmReport );
+    state.owmReport.push(newOwmReport)
   },
 
   status (state, status) {
@@ -324,7 +324,7 @@ const mutations = {
     })
 
     state.forecast = []
-  },
+  }
 }
 
 const actions = {
@@ -416,21 +416,21 @@ const actions = {
     }
   },
 
-  getLatestOwmReport({ commit, rootState, rootGetters, state}){
+  getLatestOwmReport ({ commit, rootState, rootGetters, state }) {
     const wema_name = rootGetters['site_config/wema_name']
-    if(wema_name){
+    if (wema_name) {
       const owmReportObj = state.owmReport.find(owmReport => owmReport.wema_name === wema_name)
       // request and store a new report if not cached or cached more than 1 hour ago
-      if(owmReportObj == undefined ||  (Date.now() - owmReportObj.timestamp) > (1000 * 60 * 60)){
+      if (owmReportObj == undefined || (Date.now() - owmReportObj.timestamp) > (1000 * 60 * 60)) {
         return new Promise((resolve, reject) => {
-            const url = rootState.api_endpoints.status_endpoint + `/${wema_name}/owm_report`
-            axios.get(url).then(response => {
-              commit('new_owmReport', {wema_name: wema_name, report: response.data.status.owm_report, timestamp: Date.now()})
-              resolve()
-            }).catch(e => {
-              console.log(e)
-              reject()
-            })
+          const url = rootState.api_endpoints.status_endpoint + `/${wema_name}/owm_report`
+          axios.get(url).then(response => {
+            commit('new_owmReport', { wema_name, report: response.data.status.owm_report, timestamp: Date.now() })
+            resolve()
+          }).catch(e => {
+            console.log(e)
+            reject(e)
+          })
         })
       }
     }

--- a/src/store/modules/sitestatus/index.js
+++ b/src/store/modules/sitestatus/index.js
@@ -30,7 +30,7 @@ const state = {
 
   weather: {},
   enclosure: {},
-
+  owmReport: null,
   forecast: [],
 
   screen: {},
@@ -51,6 +51,7 @@ const getters = {
 
   site: state => state.site,
   now: state => state.now,
+  owmReport: state => JSON.parse(state.owmReport),
 
   /**
    *  Site operational status:
@@ -310,6 +311,10 @@ const mutations = {
     })
 
     state.forecast = []
+  },
+
+  new_owmReport(state, owmReport){
+    state.owmReport = owmReport;
   }
 
 }
@@ -399,6 +404,26 @@ const actions = {
         commit('new_forecast_status', response.data.status)
       }).catch(e => {
         console.log(e)
+      })
+    }
+  },
+
+  //TODO: We need to store each site as its own report with its own time
+  getLatestOwmReport({ commit, rootState, rootGetters, state}){
+    const wema_name = rootGetters['site_config/wema_name']
+    // TODO check for site wema_name 
+    if( state.owmReport === null){
+      return new Promise((resolve, reject) => {
+        if(wema_name){
+          const url = rootState.api_endpoints.status_endpoint + `/${wema_name}/owm_report`
+          axios.get(url).then(response => {
+            commit('new_owmReport', response.data.status.owm_report)
+            resolve()
+          }).catch(e => {
+            console.log(e)
+            reject()
+          })
+        }
       })
     }
   },

--- a/src/store/modules/sitestatus/index.js
+++ b/src/store/modules/sitestatus/index.js
@@ -114,9 +114,9 @@ const getters = {
           colorClass: 'is-yellow'
         }
         // weather is stale
-      } else if (enclosure_not_stale && !weather_not_stale) {
+      } else if (!enclosure_not_stale && weather_not_stale) {
         return {
-          text: 'weather not reporting',
+          text: 'enclosure not reporting',
           colorClass: 'is-yellow'
         }
       }

--- a/src/store/modules/sitestatus/index.js
+++ b/src/store/modules/sitestatus/index.js
@@ -101,19 +101,19 @@ const getters = {
           text: 'operational',
           colorClass: 'is-green'
         }
-        // enclosure and weather both stale
+      // enclosure and weather both stale
       } else if (!enclosure_not_stale && !weather_not_stale) {
         return {
           text: 'offline',
           colorClass: 'is-grey'
         }
-        // enclosure is stale
+      // enclosure is stale
       } else if (!enclosure_not_stale && weather_not_stale) {
         return {
           text: 'enclosure not reporting',
           colorClass: 'is-yellow'
         }
-        // weather is stale
+      // weather is stale
       } else if (!enclosure_not_stale && weather_not_stale) {
         return {
           text: 'enclosure not reporting',


### PR DESCRIPTION
Problem:  Users wanted to see OWM reports on the home tab of site pages. 

Solution: 

- Created a component out of the OWMReport data and copied it over to the home tab. 

- Carried over property of the data only being visible to Admins. 
- In addition improved performance of app by changing the behavior of the OwmReport. Previously it would call the api every time it was mounted. Now, api calls are made in the store so they can be cached. The component will request its data from the store and the api will only be called if an hour has passed since the last report was received. 
- Added Vuex-persistedstate module
- Using persisted state module to store owmReport in localstorage