### PR TITLE
Fix/save mosaic field values

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -368,7 +368,6 @@
               style="width: 150px;"
             >
               <b-numberinput
-                :v-model="exposures[n-1].width"
                 :value="Number(exposures[n-1].width)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
@@ -378,6 +377,7 @@
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxWidthDegrees * degreesToArcminutes : maxWidthDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
                 min-step="0.001"
+                @input="val => exposures[n-1].width = val"
               />
             </b-field>
             <b-field
@@ -385,7 +385,6 @@
               style="width: 150px;"
             >
               <b-numberinput
-                :v-model="exposures[n-1].height"
                 :value="Number(exposures[n-1].height)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
@@ -395,6 +394,7 @@
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxHeightDegrees * degreesToArcminutes : maxHeightDegrees"
                 :step="exposures[n-1].zoom === 'Mosaic arcmin.' ? conditionalStep * 10 : conditionalStep"
                 min-step="0.001"
+                @input="val => exposures[n-1].height = val"
               />
             </b-field>
             <b-field
@@ -402,7 +402,6 @@
               style="width: 150px;"
             >
               <b-numberinput
-                :v-model="exposures[n-1].angle"
                 :value="Number(exposures[n-1].angle)"
                 class="angle-input"
                 size="is-small"
@@ -412,6 +411,7 @@
                 :max="90.0"
                 :step="5"
                 min-step="0.001"
+                @input="val => exposures[n-1].angle = val"
               />
             </b-field>
             <div />

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -880,7 +880,6 @@ export default {
       maxHeightDegrees: 4.5,
       degreesToArcminutes: 60,
       conditionalStep: 0.1,
-      keyDownTime: null,
       site: this.sitecode,
       warn: {
         project_name: false,


### PR DESCRIPTION
### FIX OF THIS [FEATURE](https://github.com/LCOGT/ptr_ui/pull/107#issue-1934109672)

**Background**
The new exposures fields (i.e. height, width, and angle) were not persisting when users would create a new project or modify their project.

**Fix Implementation**
I reverted `:v-model="exposures[n-1].field"` to `@input="val => exposures[n-1].field = val"`. Now projects are being saved correctly and the projects can be modified correctly and the modified values are also updated. 


### VISUALS
**Before saving project**




<img width="1728" alt="Screenshot 2023-10-17 at 12 05 46 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/3060509e-8dc9-423d-8306-b213ed7eee5c">




**Viewing saved project to modify with original values saved**




<img width="1720" alt="Screenshot 2023-10-17 at 12 06 20 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/66eddebd-4988-4344-b4dd-9b29cba8561f">




**Viewing modified project with new updated values**




<img width="1713" alt="Screenshot 2023-10-17 at 12 08 04 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/b255f1be-a157-436f-999c-d2d0cc15704d">


