### PR TITLE
Fix/api error

### DIFF
--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -59,11 +59,11 @@ const getters = {
   recent_images_condensed: state => {
     // First, generate a map of maximum SSTKNUM for each SMARTSTK
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
-      if (!cur.header || !cur.header.SMARTSTK || !cur.header.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM
+      if (!cur.SMARTSTK || !cur.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM
 
-      const num = parseInt(cur.header.SSTKNUM) // convert string to number
-      if (!acc[cur.header.SMARTSTK] || num > acc[cur.header.SMARTSTK]) {
-        acc[cur.header.SMARTSTK] = num
+      const num = parseInt(cur.SSTKNUM) // convert string to number
+      if (!acc[cur.SMARTSTK] || num > acc[cur.SMARTSTK]) {
+        acc[cur.SMARTSTK] = num
       }
       return acc
     }, {})
@@ -71,10 +71,10 @@ const getters = {
     // Now, filter the original array
     const filteredArr = state.recent_images.filter(el => {
       // Keep if missing header, SMARTSTK or SSTKNUM
-      if (!el.header || !el.header.SMARTSTK || !el.header.SSTKNUM) return true
+      if (!el.SMARTSTK || !el.SSTKNUM) return true
 
       // Keep if SSTKNUM is the maximum for its SMARTSTK
-      return el.header.SSTKNUM >= maxSSTKNUMs[el.header.SMARTSTK]
+      return el.SSTKNUM >= maxSSTKNUMs[el.SMARTSTK]
     })
     return filteredArr
   },
@@ -200,8 +200,8 @@ const actions = {
       // Reassigning value of current_image to new_image
       // If a user takes smart stack photos and they select the image as it's updating,
       // then the selected image (i.e. the thumbnail with the surrounding yellow border) keeps the yellow border
-      const current_image_SMARTSTK = state.current_image.header && state.current_image.header.SMARTSTK
-      const new_image_SMARTSTK = new_image.header && new_image.header.SMARTSTK
+      const current_image_SMARTSTK = state.current_image.header && state.current_image.SMARTSTK
+      const new_image_SMARTSTK = new_image.header && new_image.SMARTSTK
       if (current_image_SMARTSTK && current_image_SMARTSTK !== 'no' && current_image_SMARTSTK === new_image_SMARTSTK) {
         commit('setCurrentImage', new_image)
       }

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -59,7 +59,7 @@ const getters = {
   recent_images_condensed: state => {
     // First, generate a map of maximum SSTKNUM for each SMARTSTK
     const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
-      if (!cur.SMARTSTK || !cur.SSTKNUM) return acc // Skip if missing header, SMARTSTK or SSTKNUM
+      if (!cur.SMARTSTK || !cur.SSTKNUM) return acc // Skip if missing SMARTSTK or SSTKNUM
 
       const num = parseInt(cur.SSTKNUM) // convert string to number
       if (!acc[cur.SMARTSTK] || num > acc[cur.SMARTSTK]) {
@@ -70,7 +70,7 @@ const getters = {
 
     // Now, filter the original array
     const filteredArr = state.recent_images.filter(el => {
-      // Keep if missing header, SMARTSTK or SSTKNUM
+      // Keep if missing SMARTSTK or SSTKNUM
       if (!el.SMARTSTK || !el.SSTKNUM) return true
 
       // Keep if SSTKNUM is the maximum for its SMARTSTK
@@ -200,8 +200,8 @@ const actions = {
       // Reassigning value of current_image to new_image
       // If a user takes smart stack photos and they select the image as it's updating,
       // then the selected image (i.e. the thumbnail with the surrounding yellow border) keeps the yellow border
-      const current_image_SMARTSTK = state.current_image.header && state.current_image.SMARTSTK
-      const new_image_SMARTSTK = new_image.header && new_image.SMARTSTK
+      const current_image_SMARTSTK = state.current_image.SMARTSTK
+      const new_image_SMARTSTK = new_image.SMARTSTK
       if (current_image_SMARTSTK && current_image_SMARTSTK !== 'no' && current_image_SMARTSTK === new_image_SMARTSTK) {
         commit('setCurrentImage', new_image)
       }


### PR DESCRIPTION
### FIX: Images not appearing

### DESCRIPTION

**Background:**

Occasionally, images at certain sites wouldn't load and the user could only see the placeholder image. This issue was raised by Michael [here](https://lcogt.slack.com/archives/CLAQ9U79B/p1697583762292049). After investigating CloudWatch with @mgdaily, we found that the api request was returning a 413 error because there was too much data to return. The problem here was that we were sending the entire image header to the backend when really, all we needed from the header was `SMARTSTK` and `SSTKNUM` to be able to group images. The frontend issue was that images were not loading due to the backend.



**Implementation:**

After fixing the backend [here](https://github.com/LCOGT/photonranch-api/pull/68#issue-1954821044), all I had to do was change how `SMARTSTK` and `SSTKNUM` were obtained. In `recent_images_condensed` instead of checking for `cur.header.SMARTSTK` or `cur.header.SSTKNUM`, I simply checked for `cur.SMARTSTK` and `cur.SSTKNUM` because now these keys were a part of the `cur` object rather than keys inside the `header` object. I followed this structure throughout the code wherever `header` was referenced. 



### VISUALS
**Internal server error**
![Screenshot 2023-10-17 at 4 20 32 PM](https://github.com/LCOGT/ptr_ui/assets/54489472/8ad49215-3c18-4d4e-9972-eeb2f5317249)


**No images loading in eco2 site before fix**
![image](https://github.com/LCOGT/ptr_ui/assets/54489472/af07794e-06dc-4568-b5d1-c2c73bb014c0)



**Images loading in eco2 after fix**
![Screenshot 2023-10-20 at 11 21 24 AM](https://github.com/LCOGT/ptr_ui/assets/54489472/5ad5274c-98c2-41b9-bf2f-37374df5e01a)
