### PR TITLE
Fix/image carousel display

### DIFF
--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -369,7 +369,7 @@ const actions = {
       method: 'GET',
       url: rootState.api_endpoints.active_api + '/' + site + '/latest_images/1'
     }
-
+    // Doing a try...catch block instead of an await because we get better response time
     try {
       let response = await axios(firstbody)
       response = response.data

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -41,6 +41,7 @@ const state = {
 
   // recent_images is updated whenever the action 'load_latest_images' is called.
   recent_images: [],
+  lasSiteRequested: null,
   // user_images a list of all a user's images associated with their account
   // TODO: Write an action that will update a user's image list when images are added to their account
   user_images: [],
@@ -103,6 +104,7 @@ const getters = {
 const mutations = {
   setCurrentImage (state, the_current_image) { state.current_image = the_current_image },
   setRecentImages (state, recent_image_list) { state.recent_images = recent_image_list },
+  setLastSiteRequested (state, site) { state.lastSiteRequested = site },
   setUserImages (state, user_images_list) { state.user_images = user_images_list },
   show_user_data_only (state, val) { state.show_user_data_only = val },
   live_data (state, val) { state.live_data = val },
@@ -339,8 +341,10 @@ const actions = {
     // Get site and user_id
     let url = null
     const site = rootState.site_config.selected_site
-
     const filterparams = {}
+
+    // Set the lastSiteRequested before the API call
+    commit('setLastSiteRequested', site)
 
     const userid = user_id()
 
@@ -364,11 +368,11 @@ const actions = {
       url: rootState.api_endpoints.active_api + '/' + site + '/latest_images/1'
     }
 
-    await axios(firstbody).then(async response => {
+    try {
+      let response = await axios(firstbody)
       response = response.data
 
-      // Empty response:
-      if (response.length == 0) {
+      if (response.length === 0) {
         dispatch('display_placeholder_image')
         return
       }
@@ -381,76 +385,73 @@ const actions = {
 
       // Extra variable (in site timezone) for the end date noon, initialized same as noonDate
       endDate = moment(response[0].capture_date).tz(siteTimezone).hours(12).minutes(0).seconds(0).milliseconds(0)
-    }).catch(error => {
-      console.error(error)
-    })
 
-    if (siteDate.format('HH') > 12) {
-      // If the image was taken later than noon, set the start of query to noon today
-      queryStart = noonDate
+      if (siteDate.format('HH') > 12) {
+        // If the image was taken later than noon, set the start of query to noon today
+        queryStart = noonDate
 
-      // and the end to noon tomorrow
-      queryEnd = endDate.add(1, 'days')
-    } else {
-      // If the image was taken earlier than noon, set the start of query to noon yesterday
-      queryStart = noonDate.add(-1, 'days')
+        // and the end to noon tomorrow
+        queryEnd = endDate.add(1, 'days')
+      } else {
+        // If the image was taken earlier than noon, set the start of query to noon yesterday
+        queryStart = noonDate.subtract(1, 'days')
 
-      // and the end to noon today
-      queryEnd = endDate
-    }
-
-    // Set the parameters for this query
-    filterparams.site = site
-
-    // API endpoint expects the start/end dates in UTC, so convert using the site offset
-    filterparams.start_date = queryStart.add(siteOffset, 'hours').format('YYYY-MM-DD HH:mm:ss')
-    filterparams.end_date = queryEnd.add(siteOffset, 'hours').format('YYYY-MM-DD HH:mm:ss')
-
-    // If a user is logged in and they want to see only their data,
-    // add their id as a parameter for the api call
-
-    if (state.show_user_data_only && userid) {
-      filterparams.user_id = user_id
-    }
-    /**
-         * The response for this api call is a list of elements with the form:
-         *  image = {
-         *      "recency_order": int,
-         *      "site": str,
-         *      "base_filename": str,
-         *      "capture_date": int (js timestamp, in milis),
-         *      "observer": str,
-         *      "right_ascension": str,
-         *      "declination": str,
-         *      "filter_used": str,
-         *      "exposure_time": str,
-         *      "airmass": str,
-         *      "jpg_url": str,
-         *      "user_id": str,
-         *      "username": str,
-         *  }
-        */
-
-    const body = {
-      method: 'GET',
-      params: filterparams,
-      url
-    }
-
-    await axios(body).then(async response => {
-      response = response.data
-
-      // Empty response:
-      if (response.length == 0) {
-        dispatch('display_placeholder_image')
-        return
+        // and the end to noon today
+        queryEnd = endDate
       }
 
-      commit('setCurrentImage', response[0])
-      commit('setRecentImages', response)
-    }).catch(error => {
+      // Set the parameters for this query
+      filterparams.site = site
+      // API endpoint expects the start/end dates in UTC, so convert using the site offset
+      filterparams.start_date = queryStart.add(siteOffset, 'hours').format('YYYY-MM-DD HH:mm:ss')
+      filterparams.end_date = queryEnd.add(siteOffset, 'hours').format('YYYY-MM-DD HH:mm:ss')
+
+      // If a user is logged in and they want to see only their data,
+      // add their id as a parameter for the api call
+      if (state.show_user_data_only && userid) {
+        filterparams.user_id = userid
+      }
+      /**
+  //        * The response for this api call is a list of elements with the form:
+  //        *  image = {
+  //        *      "recency_order": int,
+  //        *      "site": str,
+  //        *      "base_filename": str,
+  //        *      "capture_date": int (js timestamp, in milis),
+  //        *      "observer": str,
+  //        *      "right_ascension": str,
+  //        *      "declination": str,
+  //        *      "filter_used": str,
+  //        *      "exposure_time": str,
+  //        *      "airmass": str,
+  //        *      "jpg_url": str,
+  //        *      "user_id": str,
+  //        *      "username": str,
+  //        *  }
+  //       */
+
+      // Make the second API call to get images
+      const body = {
+        method: 'GET',
+        params: filterparams,
+        url
+      }
+
+      response = await axios(body)
+      response = response.data
+
+      // Check if the current site is still the last requested before committing data
+      if (site === state.lastSiteRequested) {
+        if (response.length === 0) {
+          dispatch('display_placeholder_image')
+        } else {
+          commit('setCurrentImage', response[0])
+          commit('setRecentImages', response)
+        }
+      }
+    } catch (error) {
       console.error(error)
-    })
+    }
 
     dispatch('load_latest_info_images')
   },

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -343,6 +343,7 @@ const actions = {
     // Get site and user_id
     let url = null
     const site = rootState.site_config.selected_site
+
     const filterparams = {}
 
     // Set the lastSiteRequested before the API call
@@ -374,6 +375,7 @@ const actions = {
       let response = await axios(firstbody)
       response = response.data
 
+      // Empty response
       if (response.length === 0) {
         dispatch('display_placeholder_image')
         return
@@ -396,7 +398,7 @@ const actions = {
         queryEnd = endDate.add(1, 'days')
       } else {
         // If the image was taken earlier than noon, set the start of query to noon yesterday
-        queryStart = noonDate.subtract(1, 'days')
+        queryStart = noonDate.add(-1, 'days')
 
         // and the end to noon today
         queryEnd = endDate

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -41,7 +41,9 @@ const state = {
 
   // recent_images is updated whenever the action 'load_latest_images' is called.
   recent_images: [],
-  lasSiteRequested: null,
+  // lastSiteRequested is used to keep track of the most recently requested site by user
+  // Basically, a form of debouncing to handle rapid user input without losing the last state requested
+  lastSiteRequested: null,
   // user_images a list of all a user's images associated with their account
   // TODO: Write an action that will update a user's image list when images are added to their account
   user_images: [],


### PR DESCRIPTION
# FIX: Incorrect image display 

## Description

**Background**:
I discovered a bug where the displayed images and image carousel did not correspond to the selected site if the user clicked through sites quickly. 

**Implementation**:
I added `lastSiteRequested` to the state and initialized it to `null`. The state gets mutated to the selected site when the user switches sites. This happens in `load_latest_images` in images.js. The purpose of this is to check if `lastSiteRequested` is the same as `rootState.site_config.selected_site` (i.e. `site` in this function). If it is, then proceed with the api request. If it isn’t, then don’t make the api request. 


## Visuals:
**Before fixing bug, if user clicked through sites quickly, the image to be displayed would be aro1**
![Screenshot 2023-11-01 at 10 58 34 AM](https://github.com/LCOGT/ptr_ui/assets/54489472/196e7d56-77eb-47eb-9a13-1c59405768a7)



**After fixing issue, user can click through sites without erroneous behavior**

https://github.com/LCOGT/ptr_ui/assets/54489472/4469a0c5-55a8-444c-87b8-b699c9ed6a39


