### PR TITLE
Auto loading min zenith distance from site_config data

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -862,6 +862,9 @@ export default {
 
     // set default filter
     this.exposures[targets_index].filter = this.default_filter_selection
+
+    // loading min_zenith_dist fromt config
+    this.load_default_zenith_from_mount()
   },
   watch: {
     // This runs any time an existing project is passed into the component.
@@ -913,6 +916,10 @@ export default {
       'resetProjectForm',
       'loadProject'
     ]),
+    // Set store value for min_zenith_dist if it exists in mount config
+    load_default_zenith_from_mount () {
+      this.$store.commit('project_params/min_zenith_dist', this.selected_mount_config?.default_zenith_avoid ?? 0)
+    },
     // Used for changing values in the targets array without losing reactivity
     updateTargetsValue (indexToMatch, key, val) {
       this.targets = this.targets.map((obj, index) => {
@@ -1232,7 +1239,8 @@ export default {
       'available_sites_real',
       'available_sites_simulated',
       'filter_wheel_options',
-      'default_filter_selection'
+      'default_filter_selection',
+      'selected_mount_config'
     ]),
     ...mapState('site_config', ['global_config']),
     ...mapState('user_data', [


### PR DESCRIPTION
Feature request: the automatic loading from config of zenith value if it exists

Implementation: 
This method is called on createProjectForm page mount. It will look and see if there is a default_zenith value for that site and set the project params store equal to it. Since the form is v-modeled from the project params vuex store, this change will appear on the ui box min zenith distance as well

This 5 value was loaded from site_config>mount config>default zenith. If the mount config or zenith default do not exist the value defaults to 0
![Screenshot 2023-11-13 at 2 05 16 PM](https://github.com/LCOGT/ptr_ui/assets/54085254/def658b1-8d35-44ab-81f1-84575f710733)
