### PR TITLE
Update/observe page UI changes

### DIFF
--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -35,148 +35,11 @@
 
       <!-- Collapsible panels on the right of the image -->
       <div class="image-tools-area">
-
-        <div v-if="userIsAdmin" class="obs-config-box">
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Manual Telescope</div>
-            <StatusVal :status-item="scopeInManualMode" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_set_scope_to_manual_mode"
-              >Set Manual</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_set_scope_to_automatic_mode"
-              >Set Auto</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Sun Safety</div>
-            <StatusVal :status-item="sunSafetyMode" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_sun_safety_on"
-              >Enable</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_sun_safety_off"
-              >Disable</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Moon Safety</div>
-            <StatusVal :status-item="moonSafetyMode" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_moon_safety_on"
-              >Enable</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_moon_safety_off"
-              >Disable</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Altitude Safety</div>
-            <StatusVal :status-item="altitudeSafetyMode" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_altitude_safety_on"
-              >Enable</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_altitude_safety_off"
-              >Disable</CommandButton>
-            </div>
-          </div>
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Daytime Safety</div>
-            <StatusVal :status-item="daytimeExposureSafetyMode" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_daytime_exposure_safety_on"
-              >Enable</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_daytime_exposure_safety_off"
-              >Disable</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Simulate Open Roof</div>
-            <StatusVal :status-item="simulatingOpenRoof" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_start_simulating_open_roof"
-              >Start</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_stop_simulating_open_roof"
-              >Stop</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Who Can Operate</div>
-            <StatusVal :status-item="adminOwnerCommandsOnly" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_admin_owner_commands_only_true"
-              >Owner</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_admin_owner_commands_only_false"
-              >Anyone</CommandButton>
-            </div>
-          </div>
-
-          <div class="obs-config-control-group">
-            <div class="obs-config-title">Pointing Reference</div>
-            <StatusVal :status-item="pointingReference" style="width: 100%;"/>
-            <div class="obs-config-command-button-group">
-              <CommandButton
-                class="is-small obs-config-command-button"
-                admin
-                :data="obs_configure_pointing_reference_on"
-              >Enable</CommandButton>
-              <CommandButton
-                class="button admin is-small obs-config-command-button"
-                admin
-                :data="obs_configure_pointing_reference_off"
-              >Disable</CommandButton>
-            </div>
-          </div>
-
-        </div>
-
         <div class="obs-config-box" style="padding-bottom: calc(1em - 11.25px); justify-content: space-between;">
-          <UiSyncControls />
-          <div style="width: 1px; height: 30px; border-left: 1px solid grey; margin: 0 1em;" />
+          <!--
+            <UiSyncControls />
+            <div style="width: 1px; height: 30px; border-left: 1px solid grey; margin: 0 1em;" />
+          -->
           <NightLog :site="sitecode" />
         </div>
 
@@ -187,6 +50,148 @@
           >
             <command-tabs-accordion class="command-tab-accordion is-hidden-desktop" />
             <command-tabs-wide class="command-tabs-wide is-hidden-touch" />
+          </b-tab-item>
+
+          <b-tab-item
+            label="telescope"
+            :value="'telescope'"
+          >
+            <div v-if="userIsAdmin" class="obs-config-box">
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Manual Telescope</div>
+                <StatusVal :status-item="scopeInManualMode" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_set_scope_to_manual_mode"
+                  >Set Manual</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_set_scope_to_automatic_mode"
+                  >Set Auto</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Sun Safety</div>
+                <StatusVal :status-item="sunSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_sun_safety_on"
+                  >Enable</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_sun_safety_off"
+                  >Disable</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Moon Safety</div>
+                <StatusVal :status-item="moonSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_moon_safety_on"
+                  >Enable</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_moon_safety_off"
+                  >Disable</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Altitude Safety</div>
+                <StatusVal :status-item="altitudeSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_altitude_safety_on"
+                  >Enable</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_altitude_safety_off"
+                  >Disable</CommandButton>
+                </div>
+              </div>
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Daytime Safety</div>
+                <StatusVal :status-item="daytimeExposureSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_daytime_exposure_safety_on"
+                  >Enable</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_daytime_exposure_safety_off"
+                  >Disable</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Simulate Open Roof</div>
+                <StatusVal :status-item="simulatingOpenRoof" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_start_simulating_open_roof"
+                  >Start</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_stop_simulating_open_roof"
+                  >Stop</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Who Can Operate</div>
+                <StatusVal :status-item="adminOwnerCommandsOnly" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_admin_owner_commands_only_true"
+                  >Owner</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_admin_owner_commands_only_false"
+                  >Anyone</CommandButton>
+                </div>
+              </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">Pointing Reference</div>
+                <StatusVal :status-item="pointingReference" style="width: 100%;"/>
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_pointing_reference_on"
+                  >Enable</CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_pointing_reference_off"
+                  >Disable</CommandButton>
+                </div>
+              </div>
+            </div>
           </b-tab-item>
 
           <b-tab-item

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -57,8 +57,8 @@
 
           <b-tab-item
             v-if="userIsAdmin"
-            label="telescope"
-            :value="'telescope'"
+            label="telescope config"
+            :value="'telescope config'"
           >
             <div
               class="obs-config-box"

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -56,11 +56,11 @@
           </b-tab-item>
 
           <b-tab-item
+            v-if="userIsAdmin"
             label="telescope"
             :value="'telescope'"
           >
             <div
-              v-if="userIsAdmin"
               class="obs-config-box"
             >
               <div class="obs-config-control-group">

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -35,7 +35,10 @@
 
       <!-- Collapsible panels on the right of the image -->
       <div class="image-tools-area">
-        <div class="obs-config-box" style="padding-bottom: calc(1em - 11.25px); justify-content: space-between;">
+        <div
+          class="obs-config-box"
+          style="padding-bottom: calc(1em - 11.25px); justify-content: space-between;"
+        >
           <!--
             <UiSyncControls />
             <div style="width: 1px; height: 30px; border-left: 1px solid grey; margin: 0 1em;" />
@@ -56,139 +59,214 @@
             label="telescope"
             :value="'telescope'"
           >
-            <div v-if="userIsAdmin" class="obs-config-box">
+            <div
+              v-if="userIsAdmin"
+              class="obs-config-box"
+            >
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Manual Telescope</div>
-                <StatusVal :status-item="scopeInManualMode" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Manual Telescope
+                </div>
+                <StatusVal
+                  :status-item="scopeInManualMode"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_set_scope_to_manual_mode"
-                  >Set Manual</CommandButton>
+                  >
+                    Set Manual
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_set_scope_to_automatic_mode"
-                  >Set Auto</CommandButton>
+                  >
+                    Set Auto
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Sun Safety</div>
-                <StatusVal :status-item="sunSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Sun Safety
+                </div>
+                <StatusVal
+                  :status-item="sunSafetyMode"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_sun_safety_on"
-                  >Enable</CommandButton>
+                  >
+                    Enable
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_sun_safety_off"
-                  >Disable</CommandButton>
+                  >
+                    Disable
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Moon Safety</div>
-                <StatusVal :status-item="moonSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Moon Safety
+                </div>
+                <StatusVal
+                  :status-item="moonSafetyMode"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_moon_safety_on"
-                  >Enable</CommandButton>
+                  >
+                    Enable
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_moon_safety_off"
-                  >Disable</CommandButton>
+                  >
+                    Disable
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Altitude Safety</div>
-                <StatusVal :status-item="altitudeSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Altitude Safety
+                </div>
+                <StatusVal
+                  :status-item="altitudeSafetyMode"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_altitude_safety_on"
-                  >Enable</CommandButton>
+                  >
+                    Enable
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_altitude_safety_off"
-                  >Disable</CommandButton>
+                  >
+                    Disable
+                  </CommandButton>
                 </div>
               </div>
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Daytime Safety</div>
-                <StatusVal :status-item="daytimeExposureSafetyMode" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Daytime Safety
+                </div>
+                <StatusVal
+                  :status-item="daytimeExposureSafetyMode"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_daytime_exposure_safety_on"
-                  >Enable</CommandButton>
+                  >
+                    Enable
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_daytime_exposure_safety_off"
-                  >Disable</CommandButton>
+                  >
+                    Disable
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Simulate Open Roof</div>
-                <StatusVal :status-item="simulatingOpenRoof" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Simulate Open Roof
+                </div>
+                <StatusVal
+                  :status-item="simulatingOpenRoof"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_start_simulating_open_roof"
-                  >Start</CommandButton>
+                  >
+                    Start
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_stop_simulating_open_roof"
-                  >Stop</CommandButton>
+                  >
+                    Stop
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Who Can Operate</div>
-                <StatusVal :status-item="adminOwnerCommandsOnly" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Who Can Operate
+                </div>
+                <StatusVal
+                  :status-item="adminOwnerCommandsOnly"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_admin_owner_commands_only_true"
-                  >Owner</CommandButton>
+                  >
+                    Owner
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_admin_owner_commands_only_false"
-                  >Anyone</CommandButton>
+                  >
+                    Anyone
+                  </CommandButton>
                 </div>
               </div>
 
               <div class="obs-config-control-group">
-                <div class="obs-config-title">Pointing Reference</div>
-                <StatusVal :status-item="pointingReference" style="width: 100%;"/>
+                <div class="obs-config-title">
+                  Pointing Reference
+                </div>
+                <StatusVal
+                  :status-item="pointingReference"
+                  style="width: 100%;"
+                />
                 <div class="obs-config-command-button-group">
                   <CommandButton
                     class="is-small obs-config-command-button"
                     admin
                     :data="obs_configure_pointing_reference_on"
-                  >Enable</CommandButton>
+                  >
+                    Enable
+                  </CommandButton>
                   <CommandButton
                     class="button admin is-small obs-config-command-button"
                     admin
                     :data="obs_configure_pointing_reference_off"
-                  >Disable</CommandButton>
+                  >
+                    Disable
+                  </CommandButton>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Wayne's UI request: move the telescope options to their own tab and to comment out leader follower buttons

Moved the options that form the block of controls ranging from manual telescope to pointing reference to a tab located next to controls named "Telescope Config"

In addition commented out the Leader and Follower tabs

As you can see below the config for telescope that was previously on top is now on its own tab that is only visible when you are an admin or owner

BEFORE:
![Screenshot 2023-11-14 at 11 09 24 AM](https://github.com/LCOGT/ptr_ui/assets/54085254/ffb68636-b55c-4423-9c15-04c258358209)


AFTER:
[
![Screenshot 2023-11-14 at 11 04 56 AM](https://github.com/LCOGT/ptr_ui/assets/54085254/59d92f88-d372-4296-9c4a-c634aaf15a19)
](url)