### PR TITLE
removed observing side replace with ascending, descending

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -433,23 +433,12 @@
         <div class="flex-row">
           <b-field label="Observing Side">
             <b-field>
-              <b-radio-button
-                v-model="observing_side"
-                type="is-light"
-                native-value="east_only"
-              >
-                <b-icon icon="check" />
-                <span>Ascending</span>
-              </b-radio-button>
-
-              <b-radio-button
-                v-model="observing_side"
-                type="is-light"
-                native-value="west_only"
-              >
-                <b-icon icon="check" />
-                <span>Descending</span>
-              </b-radio-button>
+              <b-checkbox v-model="ascending">
+                Ascending
+              </b-checkbox>
+              <b-checkbox v-model="descending">
+                Descending
+              </b-checkbox>
             </b-field>
           </b-field>
         </div>
@@ -1169,7 +1158,8 @@ export default {
       'targets',
       'project_is_active',
       'generic_instrument',
-      'observing_side',
+      'ascending',
+      'descending',
       'ra_offset',
       'ra_offset_units',
       'dec_offset',

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -39,7 +39,8 @@ const state = {
   // Project constraints below
   project_is_active: true,
   generic_instrument: 'Main Camera', // removed from ui with options Auxiliary, Echelle, UXEX, Planet, IR at waynes request
-  observing_side: 'flip_ok', // can be ['flip_ok', 'no_flip', 'east_only', 'west_only']
+  ascending: false,
+  descending: false,
   ra_offset: 0.0,
   ra_offset_units: 'deg',
   dec_offset: 0.0,
@@ -71,7 +72,8 @@ const getters = {
     return {
       project_is_active: state.project_is_active,
       generic_instrument: state.generic_instrument,
-      observing_side: state.observing_side,
+      ascending: state.ascending,
+      descending: state.descending,
       ra_offset: state.ra_offset,
       ra_offset_units: state.ra_offset_units,
       dec_offset: state.dec_offset,
@@ -145,7 +147,8 @@ const mutations = {
 
   project_is_active (state, val) { state.project_is_active = val },
   generic_instrument (state, val) { state.generic_instrument = val },
-  observing_side (state, val) { state.observing_side = val },
+  ascending (state, val) { state.ascending = val },
+  descending (state, val) { state.descending = val },
   ra_offset (state, val) { state.ra_offset = val },
   ra_offset_units (state, val) { state.ra_offset_units = val },
   dec_offset (state, val) { state.dec_offset = val },

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -39,8 +39,8 @@ const state = {
   // Project constraints below
   project_is_active: true,
   generic_instrument: 'Main Camera', // removed from ui with options Auxiliary, Echelle, UXEX, Planet, IR at waynes request
-  ascending: false,
-  descending: false,
+  ascending: true,
+  descending: true,
   ra_offset: 0.0,
   ra_offset_units: 'deg',
   dec_offset: 0.0,


### PR DESCRIPTION
Request: Allow both ascending and descending to be selected instead of just one or the other

Previously we had a state variable called observing_side that could only be ascending OR descending. But some observations would like to follow a target as its ascending and then switch to continue following while descending. To do this we need to allow for both options to be selected independently. 

Default behavior will be true for both values

replaced the state variable observing_side from project_params, instead to support the selection of both ascending and descending the field was replaced with two checkboxes and the state was replaced with two new states 'ascending' and 'descending' that will be sent to site code instead

