### PR TITLE
Feature/auto centering telescope button

### DIFF
--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -269,6 +269,32 @@
                   </CommandButton>
                 </div>
               </div>
+
+              <div class="obs-config-control-group">
+                <div class="obs-config-title">
+                  Auto Center
+                </div>
+                <StatusVal
+                  :status-item="autoCenter"
+                  style="width: 100%;"
+                />
+                <div class="obs-config-command-button-group">
+                  <CommandButton
+                    class="is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_auto_center_on"
+                  >
+                    Enable
+                  </CommandButton>
+                  <CommandButton
+                    class="button admin is-small obs-config-command-button"
+                    admin
+                    :data="obs_configure_auto_center_off"
+                  >
+                    Disable
+                  </CommandButton>
+                </div>
+              </div>
             </div>
           </b-tab-item>
 
@@ -501,7 +527,8 @@ export default {
       'scopeInManualMode',
       'sunSafetyMode',
       'simulatingOpenRoof',
-      'pointingReference'
+      'pointingReference',
+      'autoCenter'
     ]),
 
     active_image_tools_tab: {

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -788,6 +788,12 @@ export const commands_mixin = {
     },
     obs_configure_pointing_reference_off () {
       return this.base_command('obs', 'configure_pointing_reference_off', '')
+    },
+    obs_configure_auto_center_on () {
+      return this.base_command('obs', 'obs_configure_auto_center_on', '')
+    },
+    obs_configure_auto_center_off () {
+      return this.base_command('obs', 'obs_configure_auto_center_off', '')
     }
   }
 }

--- a/src/store/modules/sitestatus/getters/obs_settings_getters.js
+++ b/src/store/modules/sitestatus/getters/obs_settings_getters.js
@@ -123,6 +123,22 @@ const pointingReference = (state, getters) => {
   }
 }
 
+const autoCenter = (state, getters) => {
+  if (state.obs_settings && 'auto_center_on' in state.obs_settings) {
+    return {
+      name: 'Auto Center',
+      val: state.obs_settings.auto_center_on ? 'On' : 'Off',
+      is_stale: isStale(getters)
+    }
+  } else {
+    return {
+      name: 'Auto Center',
+      val: 'missing `auto_center_on`',
+      is_stale: true
+    }
+  }
+}
+
 export default {
   adminOwnerCommandsOnly,
   obsSettingsGenericGetter,
@@ -134,5 +150,6 @@ export default {
   scopeInManualMode,
   sunSafetyMode,
   simulatingOpenRoof,
-  pointingReference
+  pointingReference,
+  autoCenter
 }


### PR DESCRIPTION
Michael and Wayne requested to add an OBS setting in telescope config for auto center that they will use to run some of Michael's auto centering site code. 

Updates: 
- added new CommandButtons for auto centering
- new mixins for sending the obs_configure_auto_center_on and obs_configure_auto_center_off commands to jobs api
- getter to update the status of the auto_center for the ui

need to look into why it says missing, but believe it is because the site code doesn't catch this job yet since the job is bring successfully sent to the jobs dybamodb 

Below in the image you can see the new button in the UI, and in the inspect tab you can see the new command being sent.

<img width="1637" alt="Screenshot 2023-11-15 at 3 24 49 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/085a03aa-fd57-45f9-af3f-2a01ca83f0d8">

The record stored in the jobs dynamodb table 
<img width="619" alt="Screenshot 2023-11-15 at 4 31 51 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/f69c45a4-68fb-422d-bbd6-59b5d88b2c2b">

