### PR TITLE
Update pointing information to pull from mount status

### DIFF
--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -22,7 +22,6 @@ const dec = (state, getters) => {
 const azimuth = (state, getters) => {
   const name = 'Azimuth'
   const val = parseFloat(getters.mount_state.azimuth?.val)?.toFixed(4) ?? '-'
-
   const is_stale = isItemStale(getters, 'mount_state', 'azimuth')
   return { name, val, is_stale }
 }

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -5,6 +5,83 @@ function get_val (getters, key) {
   return getters.mount_state[key]?.val ?? '-'
 }
 
+const ra = (state, getters) => {
+  const name = 'Ra'
+  const val = parseFloat(getters.mount_state.right_ascension?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'right_ascension')
+  return { name, val, is_stale }
+}
+
+const dec = (state, getters) => {
+  const name = 'Dec'
+  const val = parseFloat(getters.mount_state.declination?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'declination')
+  return { name, val, is_stale }
+}
+
+const azimuth = (state, getters) => {
+  const name = 'Azimuth'
+  const val = parseFloat(getters.mount_state.azimuth?.val)?.toFixed(4) ?? '-'
+
+  const is_stale = isItemStale(getters, 'mount_state', 'azimuth')
+  return { name, val, is_stale }
+}
+
+const altitude = (state, getters) => {
+  const name = 'Altitude'
+  const val = parseFloat(getters.mount_state.altitude?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'altitude')
+  return { name, val, is_stale }
+}
+
+const sidereal_time = (state, getters) => {
+  const name = 'Sidereal Time'
+  const val = get_val(getters, 'sidereal_time')
+  const is_stale = isItemStale(getters, 'telescope_state', 'sidereal_time')
+  return { name, val, is_stale }
+}
+
+const zenith_distance = (state, getters) => {
+  const name = 'Zenith Dist.'
+  const val = parseFloat(getters.mount_state.zenith_distance?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'zenith_distance')
+  return { name, val, is_stale }
+}
+
+const airmass = (state, getters) => {
+  const name = 'Airmass'
+  // const val = get_val(getters, '')
+  const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'airmass')
+  return { name, val, is_stale }
+}
+
+const refraction = (state, getters) => {
+  const name = 'Refraction'
+  const val = parseFloat(getters.mount_state.refraction?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'refraction')
+  return { name, val, is_stale }
+}
+
+const hour_angle = (state, getters) => {
+  const name = 'HA'
+  let val
+  const is_stale = isItemStale(getters, 'mount_state', 'azimuth') &&
+    isItemStale(getters, 'mount_state', 'right_ascension')
+
+  let ha = getters.mount_state.sidereal_time?.val - getters.mount_state.right_ascension?.val
+  if (isNaN(ha)) {
+    val = '-' // if sidereal_time or right_ascension is not provided, can't calculate hour_angle.
+  } else {
+    if (ha < -12) { ha += 24 } // hours, since we're in decimal
+    if (ha > 12) { ha -= 24 } // hours, since we're in decimal
+    ha = ha.toFixed(3)
+    if (ha > 0) { ha = '+' + ha }
+    val = ha
+  }
+  return { name, val, is_stale }
+}
+
 const mount_state = (state, getters, rootState) => {
   return state.mount[rootState.site_config.selected_mount] ?? {}
 }
@@ -60,6 +137,15 @@ const mount_message = (state, getters) => {
 }
 
 export default {
+  ra,
+  dec,
+  azimuth,
+  altitude,
+  sidereal_time,
+  zenith_distance,
+  airmass,
+  refraction,
+  hour_angle,
   mount_state,
   mount_is_slewing,
   mount_is_parked,

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -50,7 +50,6 @@ const zenith_distance = (state, getters) => {
 
 const airmass = (state, getters) => {
   const name = 'Airmass'
-  // const val = get_val(getters, '')
   const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
   const is_stale = isItemStale(getters, 'mount_state', 'airmass')
   return { name, val, is_stale }

--- a/src/store/modules/sitestatus/getters/telescope_getters.js
+++ b/src/store/modules/sitestatus/getters/telescope_getters.js
@@ -9,8 +9,6 @@ const telescope_state = (state, getters, rootState) => {
   return state.telescope?.[rootState.site_config.selected_telescope] ?? {}
 }
 
-
-
 const telescope_message = (state, getters) => {
   const name = 'Telescope Message'
   const val = get_val(getters, 'message')

--- a/src/store/modules/sitestatus/getters/telescope_getters.js
+++ b/src/store/modules/sitestatus/getters/telescope_getters.js
@@ -9,80 +9,7 @@ const telescope_state = (state, getters, rootState) => {
   return state.telescope?.[rootState.site_config.selected_telescope] ?? {}
 }
 
-const ra = (state, getters) => {
-  const name = 'Ra'
-  const val = parseFloat(getters.telescope_state.right_ascension?.val)?.toFixed(4) ?? '-'
-  const is_stale = isItemStale(getters, 'telescope_state', 'right_ascension')
-  return { name, val, is_stale }
-}
 
-const dec = (state, getters) => {
-  const name = 'Dec'
-  const val = parseFloat(getters.telescope_state.declination?.val)?.toFixed(4) ?? '-'
-  const is_stale = isItemStale(getters, 'telescope_state', 'declination')
-  return { name, val, is_stale }
-}
-
-const azimuth = (state, getters) => {
-  const name = 'Azimuth'
-  const val = get_val(getters, 'azimuth')
-  const is_stale = isItemStale(getters, 'telescope_state', 'azimuth')
-  return { name, val, is_stale }
-}
-
-const altitude = (state, getters) => {
-  const name = 'Altitude'
-  const val = get_val(getters, 'altitude')
-  const is_stale = isItemStale(getters, 'telescope_state', 'altitude')
-  return { name, val, is_stale }
-}
-
-const sidereal_time = (state, getters) => {
-  const name = 'Sidereal Time'
-  const val = get_val(getters, 'sidereal_time')
-  const is_stale = isItemStale(getters, 'telescope_state', 'sidereal_time')
-  return { name, val, is_stale }
-}
-
-const zenith_distance = (state, getters) => {
-  const name = 'Zenith Dist.'
-  const val = get_val(getters, 'zenith_distance')
-  const is_stale = isItemStale(getters, 'telescope_state', 'zenith_distance')
-  return { name, val, is_stale }
-}
-
-const airmass = (state, getters) => {
-  const name = 'Airmass'
-  const val = get_val(getters, 'airmass')
-  const is_stale = isItemStale(getters, 'telescope_state', 'airmass')
-  return { name, val, is_stale }
-}
-
-const refraction = (state, getters) => {
-  const name = 'Refraction'
-  const val = get_val(getters, 'refraction')
-  const is_stale = isItemStale(getters, 'telescope_state', 'refraction')
-  return { name, val, is_stale }
-}
-
-const hour_angle = (state, getters) => {
-  const name = 'HA'
-  let val
-  const is_stale = isItemStale(getters, 'telescope_state', 'azimuth') &&
-    isItemStale(getters, 'telescope_state', 'right_ascension')
-
-  let ha = getters.telescope_state.sidereal_time?.val - getters.telescope_state.right_ascension?.val
-  if (isNaN(ha)) {
-    val = '-' // if sidereal_time or right_ascension is not provided, can't calculate hour_angle.
-  } else {
-    if (ha < -12) { ha += 24 } // hours, since we're in decimal
-    if (ha > 12) { ha -= 24 } // hours, since we're in decimal
-    ha = ha.toFixed(3)
-    if (ha > 0) { ha = '+' + ha }
-    val = ha
-  }
-  return { name, val, is_stale }
-}
 
 const telescope_message = (state, getters) => {
   const name = 'Telescope Message'
@@ -93,14 +20,5 @@ const telescope_message = (state, getters) => {
 
 export default {
   telescope_state,
-  ra,
-  dec,
-  azimuth,
-  altitude,
-  sidereal_time,
-  zenith_distance,
-  airmass,
-  refraction,
-  hour_angle,
   telescope_message
 }


### PR DESCRIPTION
Telescope status is intended for other things, and was always a direct copy of the mount status - we had always relied on pointing being part of the telescope status, but it is no longer part of that, so switch the frontend to pull pointing information from the mount status instead.

This has been tested locally, and pointing information now shows at all sites!