### PR TITLE
Fixed reactivity when updating images and current image edge case

### DIFF
--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -83,6 +83,7 @@ const getters = {
 const mutations = {
   setCurrentImage (state, the_current_image) { state.current_image = the_current_image },
   setRecentImages (state, recent_image_list) { state.recent_images = recent_image_list },
+  setRecentImagesIndex (state, { oldIndex, newImage }) { Vue.set(state.recent_images, oldIndex, newImage) },
   setLastSiteRequested (state, site) { state.lastSiteRequested = site },
   setUserImages (state, user_images_list) { state.user_images = user_images_list },
   show_user_data_only (state, val) { state.show_user_data_only = val },
@@ -176,7 +177,11 @@ const actions = {
       }
       // Otherwise, replace the old version with the new one we fetched.
       else {
-        recent_images[old_image_index] = new_image
+        commit('setRecentImagesIndex', { oldIndex: old_image_index, newImage: new_image })
+        // handle the edge case where current image is the image that was updated
+        if (state.current_image.baseFilename == new_image.baseFilename) {
+          commit('setCurrentImage', new_image)
+        }
       }
       // Reassigning value of current_image to new_image
       // If a user takes smart stack photos and they select the image as it's updating,


### PR DESCRIPTION
Problem: info headers on the observe tab would not update when site code updated the detail information

Explanation: previously the code was not triggering reactivity when replacing an image with its updated version. Also the edge case where the image being viewed was the image being updated 
was not handled. These changes properly trigger vue reactivity so components relying on the recent_images list refresh as well as update the current image if that is the image being updated.

Solution: added a mutation method for updating the vue state recent images. It uses Vue.set which triggers the reactivity of that state. replaced the old unreactive line with the mutation. 
Also added an if statement to check if the current image is the image being updated. If this is the case then the current image is changed to the new updated image so data will show up without having to refresh the page. 

Results and Testing: With two laptops, one running live code and one running the changes on localhost some exposures were taken on aro1. The images showed up with no filter data, however after a bit the machine with the new code automatically updated when it got the data with vues reactivity, whereas the old machine had to switch images and refresh the page to get the data.

<img width="596" alt="Screenshot 2023-12-06 at 11 58 51 AM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/70c542c9-05a7-4edb-9e7c-69cbf8b72427">

