### PR TITLE
Feature/aladin fov scaling

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -822,7 +822,7 @@ export default {
       maxDegrees: this.getMosaicLimits(),
       degreesToArcminutes: 60,
       conditionalStep: 0.1,
-      sizeInDegrees: this.getSizeDegrees(),
+      sizeInDegrees: this.camera_size_degrees,
       site: this.sitecode,
       warn: {
         project_name: false,
@@ -1170,9 +1170,9 @@ export default {
 
     // Getting 'Small sq.' adjusted width and height values. This is done by getting the smaller of the two camera sizes, multiplying it by the 1x1 pixels (i.e. getPixels()) and dividing all by 3600
     getSmallSquareValues () {
-      const size_x = this.get_camera_size_x
-      const size_y = this.get_camera_size_y
-      const pix = this.get_pixels
+      const size_x = this.camera_size_x
+      const size_y = this.camera_size_y
+      const pix = this.pixel_scale
       let smallSquare = 1
       if (size_x && size_y && pix) {
         if (size_x < size_y) {
@@ -1186,27 +1186,10 @@ export default {
       return smallSquare
     },
 
-    // Getting size in degrees to be able to get mosaic limits for 'Mosaic arcmin.' and 'Mosaic deg.' zoom selections
-    // as well as to adjust width and height depending on zoom selection (i.e. adjustSize())
-    getSizeDegrees () {
-      const size_x = this.get_camera_size_x
-      const size_y = this.get_camera_size_y
-      const pix = this.get_pixels
-      let sizeDegrees = 1
-      if (size_x && size_y && pix) {
-        if (size_x > size_y) {
-          sizeDegrees = (size_x * pix) / 3600
-        } else {
-          sizeDegrees = (size_y * pix) / 3600
-        }
-      }
-      return sizeDegrees
-    },
-
     // Getting limits for width and height for 'Mosaic arcmin.' and 'Mosaic deg.' zoom selections
     getMosaicLimits () {
       let limit = 5
-      const sizeDeg = this.getSizeDegrees()
+      const sizeDeg = this.camera_size_degrees
       if (sizeDeg) {
         const fiveFieldsOfView = sizeDeg * limit
         if (fiveFieldsOfView > limit) {
@@ -1227,7 +1210,7 @@ export default {
     // Converting size values depending on what 'zoom' is selected
     adjustSize (zoom) {
       // Getting adjusted width and height values
-      const size = this.getSizeDegrees()
+      const size = this.camera_size_degrees
       let sizeVal
       // Full and Big sq. share the same value since they both use the largest of the camera sizes
       if (zoom === 'Full' || zoom === 'Big sq.') {
@@ -1351,9 +1334,10 @@ export default {
       'default_filter_selection',
       'selected_mount_config',
       'camera_config',
-      'get_pixels',
-      'get_camera_size_x',
-      'get_camera_size_y'
+      'pixel_scale',
+      'camera_size_x',
+      'camera_size_y',
+      'camera_size_degrees'
     ]),
     ...mapState('site_config', ['global_config']),
     ...mapState('user_data', [

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -681,15 +681,19 @@ export default {
     this.$loadScript('https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js')
       .then(async () => {
         // Default: load aladin on m33, but use coords in mount fields if possible.
-        let target = 'M33'
+        let target = 'M65'
         if (parseFloat(this.mount_ra) && parseFloat(this.mount_dec)) {
           target = `${15 * this.mount_ra} ${this.mount_dec}`
         }
 
+        // Defaults FOV of 1, use pixel size of camera if present
+        const fov = this.autoAladinFov()
+        console.log('fov: ' + fov)
+
         // Initialize Aladin
         this.aladin = A.aladin('#aladin-lite-div', {
           survey: 'P/DSS2/color',
-          fov: 1,
+          fov,
           target,
           cooFrame: 'ICRSd',
           showFullscreenControl: false,
@@ -950,6 +954,24 @@ export default {
 
       if (window.screen.availWidth < 970) {
         setTimeout(function () { document.getElementById('common-targets').scrollIntoView({ behavior: 'smooth' }) }, 30) }
+    },
+
+    // calculates the fov based on the max side length for the sites camera, if parameters are undefined by site defaults to a fov of 1
+    // TODO Carolina is creating a get fov function that we will just import and reuse here or above, most likely a getter
+    autoAladinFov () {
+      const camConfig = this.$store.getters['site_config/get_camera_config']
+      const pixelScale = camConfig?.settings?.onebyone_pix_scale
+      const camSizeX = camConfig?.camera_size_x
+      const camSizeY = camConfig?.camera_size_y
+      const DEG_PER_ARCSEC = 1 / 3600
+
+      if (camConfig === undefined || pixelScale === undefined || camSizeX === undefined || camSizeY === undefined) {
+        return 1
+      }
+
+      const pixels = Math.max(camSizeX, camSizeY)
+
+      return pixelScale * pixels * DEG_PER_ARCSEC
     }
 
   },

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -681,14 +681,13 @@ export default {
     this.$loadScript('https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js')
       .then(async () => {
         // Default: load aladin on m33, but use coords in mount fields if possible.
-        let target = 'M65'
+        let target = 'M17'
         if (parseFloat(this.mount_ra) && parseFloat(this.mount_dec)) {
           target = `${15 * this.mount_ra} ${this.mount_dec}`
         }
 
         // Defaults FOV of 1, use pixel size of camera if present
-        const fov = this.autoAladinFov()
-        console.log('fov: ' + fov)
+        const fov = this.camera_size_degrees
 
         // Initialize Aladin
         this.aladin = A.aladin('#aladin-lite-div', {
@@ -957,7 +956,6 @@ export default {
     },
 
     // calculates the fov based on the max side length for the sites camera, if parameters are undefined by site defaults to a fov of 1
-    // TODO Carolina is creating a get fov function that we will just import and reuse here or above, most likely a getter
     autoAladinFov () {
       const camConfig = this.$store.getters['site_config/get_camera_config']
       const pixelScale = camConfig?.settings?.onebyone_pix_scale
@@ -1062,7 +1060,8 @@ export default {
       'site_latitude',
       'site_longitude',
       'site_name',
-      'timezone'
+      'timezone',
+      'camera_size_degrees'
     ])
   }
 

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -3,7 +3,7 @@
  * that are either available for selection or currently selected and active.
  */
 
-import _, { get } from 'lodash'
+import _ from 'lodash'
 import axios from 'axios'
 import helpers from '../../utils/helpers'
 

--- a/src/store/modules/site_config.js
+++ b/src/store/modules/site_config.js
@@ -3,7 +3,7 @@
  * that are either available for selection or currently selected and active.
  */
 
-import _ from 'lodash'
+import _, { get } from 'lodash'
 import axios from 'axios'
 import helpers from '../../utils/helpers'
 
@@ -53,7 +53,7 @@ const getters = {
   },
 
   // Getting pixels to get size degrees and mosaic limits
-  get_pixels: (state, getters) => {
+  pixel_scale: (state, getters) => {
     const pixels = getters.camera_config.settings.onebyone_pix_scale
     return pixels
   },
@@ -62,14 +62,29 @@ const getters = {
   // 1. get mosaic limits for 'Mosaic arcmin.' and 'Mosaic deg.' zoom selections,
   // 2. be able to adjust preset sizes based on zoom selections
   // and 3. get adjusted width and height values for 'Small sq.' and 'Big sq.' zoom selections
-  get_camera_size_x: (state, getters) => {
+  camera_size_x: (state, getters) => {
     const camera_size_x = getters.camera_config.camera_size_x
     return camera_size_x
   },
 
-  get_camera_size_y: (state, getters) => {
+  camera_size_y: (state, getters) => {
     const camera_size_y = getters.camera_config.camera_size_y
     return camera_size_y
+  },
+
+  camera_size_degrees: (state, getters) => {
+    const pixelScale = getters.pixel_scale
+    const camSizeX = getters.camera_size_x
+    const camSizeY = getters.camera_size_y
+    const DEG_PER_ARCSEC = 1 / 3600
+
+    if (pixelScale === undefined || camSizeX === undefined || camSizeY === undefined) {
+      return 1
+    }
+
+    const max_pixels = Math.max(camSizeX, camSizeY)
+
+    return pixelScale * max_pixels * DEG_PER_ARCSEC
   },
 
   site_is_wema: state => {


### PR DESCRIPTION
Feature request: Aladin View should update FOV when changing sites

Changes
- moved aladin initialization into its own function for better readability. 
- set Aladin Fov inside sitecode's watcher so that when site changes FOV is re set for the new site
- added a new getter to camera config to calculate camera fov in degrees
- renamed getters to follow project conventions
- updated renamed getters in createProjectForm
- changed default view from M33 to M17 : )


https://github.com/LCOGT/ptr_ui/assets/54085254/910640d3-fd37-42d2-b260-adefbb044d0f

