### PR TITLE
Revert "Removing intermediate smart stack check"

### DIFF
--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -24,7 +24,7 @@
           />
           <thumbnail-row
             class="data-thumbs"
-            :images="$store.getters['images/recent_images']"
+            :images="$store.getters['images/recent_images_condensed']"
             :selected_image="current_image.image_id"
             @thumbnailClicked="setActiveImage"
           />

--- a/src/store/modules/images.js
+++ b/src/store/modules/images.js
@@ -58,6 +58,29 @@ const getters = {
   current_image: state => state.current_image,
   recent_images: state => state.recent_images,
   user_images: state => state.user_images,
+  // Uses recent_images but removes any intermediate smartstack frames, so you only see the latest version of each smart stack
+  recent_images_condensed: state => {
+    // First, generate a map of maximum SSTKNUM for each SMARTSTK
+    const maxSSTKNUMs = state.recent_images.reduce((acc, cur) => {
+      if (!cur.SMARTSTK || !cur.SSTKNUM) return acc // Skip if missing SMARTSTK or SSTKNUM
+
+      const num = parseInt(cur.SSTKNUM) // convert string to number
+      if (!acc[cur.SMARTSTK] || num > acc[cur.SMARTSTK]) {
+        acc[cur.SMARTSTK] = num
+      }
+      return acc
+    }, {})
+
+    // Now, filter the original array
+    const filteredArr = state.recent_images.filter(el => {
+      // Keep if missing SMARTSTK or SSTKNUM
+      if (!el.SMARTSTK || !el.SSTKNUM) return true
+
+      // Keep if SSTKNUM is the maximum for its SMARTSTK
+      return el.SSTKNUM >= maxSSTKNUMs[el.SMARTSTK]
+    })
+    return filteredArr
+  },
   show_user_data_only: state => state.show_user_data_only,
 
   current_image_fits_header: state => state.current_image.fits_header,


### PR DESCRIPTION
This reverts commit 64615f753e6eeb484f4eeaf44b7c411a0b623926.
Reverting this commit to bring in the original code. This function is necessary for pruning intermediate smart stacks while they are currently being captured. When it was taken out smart stacks would be the latest in the backend, but the frontend would hold onto the intermediate ones. 