### PR TITLE
Feature/Zoom Dropdown under Camera Tab

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -130,6 +130,26 @@
     </b-field>
 
     <b-field
+      horizontal
+      label="Zoom"
+    >
+      <b-select
+        v-model="zoom_options_selection"
+        placeholder="select zoom..."
+        size="is-small"
+      >
+        <option
+          v-for="(zoom, index) in zoom_options"
+          :key="index"
+          :value="zoom"
+          :selected="index === 0"
+        >
+          {{ zoom }}
+        </option>
+      </b-select>
+    </b-field>
+
+    <b-field
       v-if="camera_can_bin"
       horizontal
       label="Resolution"
@@ -328,7 +348,10 @@ export default {
   },
   data () {
     return {
-      isExpandedStatusVisible: false
+      isExpandedStatusVisible: false,
+      zoom_options: [
+        'Full', 'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
+      ]
     }
   },
 
@@ -415,6 +438,11 @@ export default {
     filter_wheel_options_selection: {
       get () { return this.$store.getters['command_params/filter_wheel_options_selection'] },
       set (val) { this.$store.commit('command_params/filter_wheel_options_selection', val) }
+    },
+
+    zoom_options_selection: {
+      get () { return this.$store.getters['command_params/zoom_options_selection'] },
+      set (val) { this.$store.commit('command_params/zoom_options_selection', val) }
     },
 
     selector_position: {

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -145,11 +145,6 @@ export default {
       set (val) { this.$store.commit('command_params/filter_wheel_options_selection', val) }
     },
 
-    zoom_options_selection: {
-      get () { return this.$store.getters['command_params/zoom_options_selection'] },
-      set (val) { this.$store.commit('command_params/zoom_options_selection', val) }
-    },
-
     selector_position: {
       get () { return this.$store.getters['command_params/selector_position'] },
       set (val) { this.$store.commit('command_params/selector_position', val) }

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -145,6 +145,11 @@ export default {
       set (val) { this.$store.commit('command_params/filter_wheel_options_selection', val) }
     },
 
+    zoom_options_selection: {
+      get () { return this.$store.getters['command_params/zoom_options_selection'] },
+      set (val) { this.$store.commit('command_params/zoom_options_selection', val) }
+    },
+
     selector_position: {
       get () { return this.$store.getters['command_params/selector_position'] },
       set (val) { this.$store.commit('command_params/selector_position', val) }

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -42,7 +42,7 @@ const state = {
   camera_de_ice_cooling: false,
 
   filter_wheel_options_selection: '',
-  zoom_options_selection: '',
+  zoom_options_selection: 'Full',
 
   selector_position: 0, // the chosen inst. selector position.
 

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -42,6 +42,7 @@ const state = {
   camera_de_ice_cooling: false,
 
   filter_wheel_options_selection: '',
+  zoom_options_selection: '',
 
   selector_position: 0, // the chosen inst. selector position.
 
@@ -80,6 +81,7 @@ const getters = {
   camera_temperature: state => state.camera_temperature,
   camera_de_ice_cooling: state => state.camera_de_ice_cooling,
   filter_wheel_options_selection: state => state.filter_wheel_options_selection,
+  zoom_options_selection: state => state.zoom_options_selection,
   selector_position: state => state.selector_position,
   focuser_relative: state => state.focuser_relative,
   focuser_absolute: state => state.focuser_absolute,
@@ -143,6 +145,7 @@ const mutations = {
   camera_temperature (state, val) { state.camera_temperature = val },
   camera_de_ice_cooling (state, val) { state.camera_de_ice_cooling = val },
   filter_wheel_options_selection (state, val) { state.filter_wheel_options_selection = val },
+  zoom_options_selection (state, val) { state.zoom_options_selection = val },
   selector_position (state, val) { state.selector_position = val },
   focuser_relative (state, val) { state.focuser_relative = val },
   focuser_absolute (state, val) { state.focuser_absolute = val },


### PR DESCRIPTION
## Feature: Zoom Dropdown Menu Under Camera Tab
### Description:



**Background:**
Wayne made a request [here](https://lcogt.slack.com/archives/CLAQ9U79B/p1702935461713609) and provided details about his request [here](https://lcogt.slack.com/archives/CLAQ9U79B/p1702950867871319). Basically, he requested for a `zoom` dropdown menu under the Camera tab so that users can have a similar experience of being at a telescope. The `zoom` should change the eyepiece and achieve the difficult to replicate experience that cheap telescopes claim to be able to provide.

**Implementation:**
The implementation was fairly simple. I added a dropdown menu to the `Camera` component that loops through the `zoom_options`. These options are in an array under `data` and they are `Full`, `Small sq.`, `71%`, `50%`, `35%`, `25%`, `18%`, `12.5%`, `9%`, and `6%`.  Then in this same component under computed properties I added a new one called `zoom_options_selection`. This first gets the getter `zoom_options_selection` from the file `commands_params` and then updates the value of `zoom_options_selection` in the Vuex store when the user changes the `zoom` value in the UI. 
The next step was to add the getters to `command_params` so that the aforementioned values can be set and mutated. This is also where I set the default value of zoom selections to `Full`. 



### Visuals:


**Default zoom value in the UI and the store**
<img width="1728" alt="Screenshot 2023-12-19 at 3 25 38 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/2903f840-a6bd-437c-bba4-562302a0fb75">


**Recording of zoom values updating in the store as user selects different values**

https://github.com/LCOGT/ptr_ui/assets/54489472/a4d29cf7-305a-4038-bb4d-4f8aa2f92cda

