### PR TITLE
Feature: camera and filter dropdown

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -139,6 +139,19 @@
         >
           {{ filter }}
         </option>
+        <option
+          disabled
+          value="------"
+        >
+          ---- Generic Filters ----
+        </option>
+        <option
+          v-for="(filter, index) in generic_filter_list"
+          :key="index"
+          :value="filter"
+        >
+          {{ filter }}
+        </option>
       </b-select>
     </b-field>
     <b-field
@@ -366,6 +379,9 @@ export default {
       ],
       quick_stacks_filter_list: [
         'RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'
+      ],
+      generic_filter_list: [
+        'Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo'
       ]
     }
   },

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -126,9 +126,21 @@
         >
           {{ filter[0] }}
         </option>
+        <option
+          disabled
+          value="------"
+        >
+          ---- Quick Stacks ----
+        </option>
+        <option
+          v-for="(filter, index) in quick_stacks_filter_list"
+          :key="index"
+          :value="filter"
+        >
+          {{ filter }}
+        </option>
       </b-select>
     </b-field>
-
     <b-field
       horizontal
       label="Zoom"
@@ -351,6 +363,9 @@ export default {
       isExpandedStatusVisible: false,
       zoom_options: [
         'Full', 'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
+      ],
+      quick_stacks_filter_list: [
+        'RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'
       ]
     }
   },

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -319,6 +319,19 @@
                 >
                   {{ filter }}
                 </option>
+                <option
+                  disabled
+                  value="------"
+                >
+                  ---- Quick Stacks ----
+                </option>
+                <option
+                  v-for="filter in quick_stacks_filter_list"
+                  :key="filter"
+                  :value="filter"
+                >
+                  {{ filter }}
+                </option>
               </b-select>
             </b-field>
             <b-field

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -814,6 +814,7 @@ export default {
       // This is used to limit the max length of the project note.
       max_fits_header_length: 68,
       generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo', 'HA', 'O3', 'S2'],
+      quick_stacks_filter_list: ['RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'],
       generic_camera_areas: [
         'Mosaic deg.', 'Mosaic arcmin.', 'Big sq.', 'Full',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -313,7 +313,7 @@
                   ---- Generic Filters ----
                 </option>
                 <option
-                  v-for="filter in generic_filters_no_duplicates"
+                  v-for="filter in generic_filter_list"
                   :key="filter"
                   :value="filter"
                 >
@@ -1386,9 +1386,10 @@ export default {
     },
 
     // Return the generic filter list without filters already reported by sites.
-    generic_filters_no_duplicates () {
-      return this.generic_filter_list.filter(item => this.project_filter_list.indexOf(item) < 0)
-    },
+    // For now, Wayne said it's okay to have duplicates
+    // generic_filters_no_duplicates () {
+    //   return this.generic_filter_list.filter(item => this.project_filter_list.indexOf(item) < 0)
+    // },
 
     // True if we're modifying a project and the name is changed.
     project_name_changed () {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -813,7 +813,7 @@ export default {
       // Pos 10 to 80, including two single quotes containing the value.
       // This is used to limit the max length of the project note.
       max_fits_header_length: 68,
-      generic_filter_list: ['Lum', 'Red', 'Green', 'Blue', 'HA', 'O3', 'S2', 'EXO'],
+      generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'Hello', 'Test', 'Test2', 'EXO2'],
       generic_camera_areas: [
         'Mosaic deg.', 'Mosaic arcmin.', 'Big sq.', 'Full',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -813,7 +813,7 @@ export default {
       // Pos 10 to 80, including two single quotes containing the value.
       // This is used to limit the max length of the project note.
       max_fits_header_length: 68,
-      generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'Hello', 'Test', 'Test2', 'EXO2'],
+      generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo', 'HA', 'O3', 'S2'],
       generic_camera_areas: [
         'Mosaic deg.', 'Mosaic arcmin.', 'Big sq.', 'Full',
         'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'


### PR DESCRIPTION
## SMALL FEATURE: ADDED FILTER DROPDOWN OPTIONS TO CAMERA AND PROJECTS 

### DESCRIPTION:

**Background:**
Wayne made a [semi-urgent request](https://lcogt.slack.com/archives/CLAQ9U79B/p1703099711684569) before the break for us to add more options to the `filter` dropdown menus in the `Camera` and `Project` tabs.


**Implementation:**
In the `CreateProjectForm` component, I added an array called `quick_stacks_filter_list` and changed the order of some elements in the `generic_filter_list`. Then, I added another option tag to add `Quick Stacks` and loop through them. And since the `b-select` tag has the `v-model` binding to the appropriate data, I didn't have to add any logic and everything is updating in the store. The exact same implementation was done for the `Camera` component. Pretty simple! 


**Important Note:**
Wayne hasn't responded as to what he wants when there are duplicate filters for `Generic filters` and `Site filters` so for now, I'm leaving it as is. I'll wait for feedback.
Feedback has been received and he said it's fine to have duplicate values. Updated code and commented out the logic where duplicate values are filtered out.


### VISUALS:

**Camera >>  filter dropdown with vuex store updating**

https://github.com/LCOGT/ptr_ui/assets/54489472/3ed15808-a602-4efd-8b83-cce739e967b6


**Project >> filter dropdown with vuex store updating**

https://github.com/LCOGT/ptr_ui/assets/54489472/365afea9-cc0c-424e-a2f4-5e40c5e95fc8


