### PR TITLE
Fix/camera zoom

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -133,8 +133,8 @@
           ---- Quick Stacks ----
         </option>
         <option
-          v-for="(filter, index) in quick_stacks_filter_list"
-          :key="index"
+          v-for="filter in quick_stacks_filter_list"
+          :key="filter"
           :value="filter"
         >
           {{ filter }}
@@ -146,8 +146,8 @@
           ---- Generic Filters ----
         </option>
         <option
-          v-for="(filter, index) in generic_filter_list"
-          :key="index"
+          v-for="filter in generic_filter_list"
+          :key="filter"
           :value="filter"
         >
           {{ filter }}

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -375,7 +375,8 @@ export default {
     return {
       isExpandedStatusVisible: false,
       zoom_options: [
-        'Full', 'Small sq.', '71%', '50%', '35%', '25%', '18%', '12.5%', '9%', '6%'
+        'Full', 'Small sq.', ' 1.5X', '2X', '3X', '4X', '6X', '8X', '12X', '16X'
+
       ],
       quick_stacks_filter_list: [
         'RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -376,7 +376,6 @@ export default {
       isExpandedStatusVisible: false,
       zoom_options: [
         'Full', 'Small sq.', ' 1.5X', '2X', '3X', '4X', '6X', '8X', '12X', '16X'
-
       ],
       quick_stacks_filter_list: [
         'RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -450,7 +450,6 @@ export const commands_mixin = {
         // object_name: 'test test test',
         username: this.username // from auth0
       }
-      console.log('opt params:', opt_params)
       // Avoid empty strings (thanks, dynamodb)
       if (this.camera_note != '') {
         opt_params.hint = this.camera_note

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -312,6 +312,7 @@ export const commands_mixin = {
       'camera_dither',
       'camera_extract',
       'camera_image_type',
+      'zoom_options_selection',
 
       'camera_cooling',
       'camera_temperature',
@@ -445,10 +446,11 @@ export const commands_mixin = {
         dither: this.camera_dither,
         extract: this.camera_extract,
         object_name: this.object_name,
+        zoom: this.zoom_options_selection,
         // object_name: 'test test test',
         username: this.username // from auth0
       }
-
+      console.log('opt params:', opt_params)
       // Avoid empty strings (thanks, dynamodb)
       if (this.camera_note != '') {
         opt_params.hint = this.camera_note


### PR DESCRIPTION
## FIX: NOW PASSING ZOOM TO OPT_PARAMS

### DESCRIPTION:



**Background:**

Wayne pointed out that the `zoom` values under the `Camera` tab were not being passed to `opt_params`. He also requested to change some of the values from % to magnification. Two birds, one stone.



**Implementation:**

Quick fix, just imported `zoom_options_selection` from `command_params` into `command_mixin` and under `opt_params` I passed `zoom: this.zoom_options_selection`. 
For the latter request, I just changed the values in the array.


### VISUALS:

**You can see in the console that there's now a `zoom` value**
<img width="1728" alt="Screenshot 2023-12-22 at 11 24 40 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/8783936c-d0ca-4897-8128-e4f62ee882f8">

**And it updates when a different selection is chosen**
<img width="1728" alt="Screenshot 2023-12-22 at 11 24 47 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/2ecd05be-5f5b-4e95-9ef0-96bb85f27247">







