### PR TITLE
Validation fixes for Create Project

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1085,8 +1085,6 @@ export default {
       }
 
       const project = this.projectToSend
-      console.log('saving new project: ')
-      console.log(project)
 
       // Make sure all warnings are false, otherwise don't create the project.
       if (Object.values(this.warn).every(x => !x)) {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -183,6 +183,14 @@
             </template>
             <b-input
               v-model="targets[0].name"
+            />
+          </b-field>
+          <b-field
+            label="Object Search"
+            style="width: 230px;"
+          >
+            <b-input
+              v-model="objectSearch"
               :disabled="!targets[0].active"
               style="max-width: 130px;"
               class="project-input"
@@ -851,6 +859,7 @@ export default {
       conditionalStep: 0.1,
       sizeInDegrees: this.camera_size_degrees,
       site: this.sitecode,
+      objectSearch: '',
       warn: {
         project_name: false,
         position_angle: false,
@@ -992,7 +1001,7 @@ export default {
     async getCoordinatesFromName () {
       const target_index = 0 // legacy, eventually we want to make `targets` a dict, not an array containing the dict
       this.object_name_search_in_progress = true
-      const name = this.targets[target_index].name
+      const name = this.objectSearch
       const search_results = await this.get_coordinates_from_object_name(name)
       this.object_name_search_in_progress = false
       if (!search_results.error) {
@@ -1003,7 +1012,7 @@ export default {
         this.updateTargetsValue(target_index, 'dec', '')
         this.$buefy.notification.open({
           duration: 10000,
-          message: 'Could not find target ' + this.targets[target_index].name,
+          message: 'Could not find target ' + this.objectSearch,
           position: 'is-top',
           type: 'is-info'
         })
@@ -1076,6 +1085,8 @@ export default {
       }
 
       const project = this.projectToSend
+      console.log('saving new project: ')
+      console.log(project)
 
       // Make sure all warnings are false, otherwise don't create the project.
       if (Object.values(this.warn).every(x => !x)) {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1020,8 +1020,8 @@ export default {
     },
 
     verifyForm () {
-      if (this.project_name === '') { this.warn.project_name = true }
-      if (this.targets[0].name === '') { this.warn.target_name = true }
+      if (this.project_name.trim() === '') { this.warn.project_name = true }
+      if (this.targets[0].name.trim() === '') { this.warn.target_name = true }
       if (this.project_name.includes('#')) {
         this.warn.project_name = true
         this.$buefy.toast.open({

--- a/src/mixins/target_names.js
+++ b/src/mixins/target_names.js
@@ -15,7 +15,7 @@ export const target_names = {
       return new Promise(resolve => {
         axios.get(url).then(response => {
           const result = JSON.parse(response.data.slice(10, -3))
-          if (!result.Target.Resolver || !result.Target.Resolver.jradeg || !result.Target.Resolver.jdedeg) {
+          if (!result.Target || !result.Target.Resolver || !result.Target.Resolver.jradeg || !result.Target.Resolver.jdedeg) {
             console.error('failed to fetch coordinates for ', common_name)
             error = true
           } else {


### PR DESCRIPTION
Micheal mentioned that projects could be created without a target name. This PR fixes that as well as a lot of other bugs I found along the way which include: hanging on empty search, no error messages for missing ra and dec, and not verifying fields when modifying a project

Changes
- new field 'Name' splitting up the functionality of the Object Search field.
- check for target name in verifyForm() so that a target name is required to create or modify a project
- warning messages for missing ra and dec fields
- error message for unknown targets are now info instead of an error

Fixes
- fixed naming for projectRa and projectDec to targetRa and targetDec
- added a VerifyForm call to modifyProject, previously it was missing
- removed unnecessary b-field tag
- removed redundant logic for checking ra and dec fields are empty in verifyForm()
- combined two separate checks for warnings into one if/else
- check for if result.Target exists to prevent hanging on an blank target search

![Screenshot 2024-02-06 at 12 04 29 PM](https://github.com/LCOGT/ptr_ui/assets/54085254/63009016-e2a2-4136-a161-14eeffba1c07)
