### PR TITLE
Small Naming changes for target page and search box

### DIFF
--- a/src/components/FormElements/TargetSearchField.vue
+++ b/src/components/FormElements/TargetSearchField.vue
@@ -10,9 +10,9 @@
         type="search"
         autocomplete="off"
         :size="size"
+        placeholder="Search for object"
         @input="$emit('input', object_name)"
         @keyup.enter.native="search_for_coordinates"
-        placeholder="Search for object"
       />
       <p class="control">
         <b-button

--- a/src/components/FormElements/TargetSearchField.vue
+++ b/src/components/FormElements/TargetSearchField.vue
@@ -12,6 +12,7 @@
         :size="size"
         @input="$emit('input', object_name)"
         @keyup.enter.native="search_for_coordinates"
+        placeholder="Search for object"
       />
       <p class="control">
         <b-button

--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -63,7 +63,7 @@
 
     <b-field
       horizontal
-      label="Object Name"
+      label="Object"
     >
       <b-input
         v-model="object_name"

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -105,7 +105,6 @@
             </b-field>
             <TargetSearchField
               v-model="mount_object"
-              label="Object search"
               size="is-small"
               @results="handle_object_name_search"
             />

--- a/src/views/Site.vue
+++ b/src/views/Site.vue
@@ -18,7 +18,7 @@
             class="button"
             :class="{'selected': subpage == 'targets'}"
           >
-            Targets
+            Sky Map
           </button>
         </router-link>
         <router-link :to="'/site/' + sitecode + '/observe'">


### PR DESCRIPTION
Wayne wanted the Targets page to be named to Sky Map and Object name in camera tab to just be object to match the search fields in the sky map tag and the projects tab.

![Screenshot 2024-02-05 at 10 52 41 AM](https://github.com/LCOGT/ptr_ui/assets/54085254/37629a1a-8c19-482c-8750-32ea89aa3b65)
