### PR TITLE
Add Read-Only Project View, Add Username to Projects Table

### DIFF
--- a/src/components/FormElements/DeclinationInput.vue
+++ b/src/components/FormElements/DeclinationInput.vue
@@ -9,10 +9,12 @@
         v-model="localDec"
         :size="size"
         lazy
+        :disabled="disabled"
       />
       <b-select
         v-model="units"
         :size="size"
+        :disabled="disabled"
       >
         <option value="deg">
           deg
@@ -27,10 +29,10 @@
 
 <script>
 export default {
-  props: ['value', 'size'],
+  props: ['value', 'size', 'disabled'],
   data () {
     return {
-      localDec: null,
+      localDec: this.value,
       units: 'deg',
       hasError: false,
       errorMessage: ''

--- a/src/components/FormElements/RightAscensionInput.vue
+++ b/src/components/FormElements/RightAscensionInput.vue
@@ -9,10 +9,12 @@
         v-model="localRa"
         :size="size"
         lazy
+        :disabled="disabled"
       />
       <b-select
         v-model="units"
         :size="size"
+        :disabled="disabled"
       >
         <option value="deg">
           deg
@@ -30,10 +32,10 @@
 
 <script>
 export default {
-  props: ['value', 'size'],
+  props: ['value', 'size', 'disabled'],
   data () {
     return {
-      localRa: null,
+      localRa: this.value,
       units: 'hours',
       hasError: false,
       errorMessage: ''

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -4,10 +4,12 @@
       <h1 class="title">
         <span v-if="cloning_existing_project"><span class="project-title-verb">Cloning: </span><i>{{ project_name }}</i></span>
         <span v-else-if="modifying_existing_project"><span class="project-title-verb">Modifying: </span><i>{{ project_name }}</i></span>
+        <span v-else-if="read_only"><span class="project-title-verb">Inspecting: </span><i>{{ project_name }}</i></span>
         <span v-else>Create new project</span>
       </h1>
       <div>
         <button
+          v-if="!read_only"
           class="button is-light is-outlined mr-1"
           @click="clearProjectForm"
         >
@@ -44,6 +46,7 @@
               v-model="project_name"
               class="project-input"
               :lazy="false"
+              :disabled="read_only"
             />
           </b-field>
 
@@ -54,9 +57,13 @@
             <b-input
               v-model="project_note"
               :maxlength="max_fits_header_length"
+              :disabled="read_only"
             />
           </b-field>
-          <ProjectSitesSelector :obs-id="sitecode" />
+          <ProjectSitesSelector
+            :obs-id="sitecode"
+            :disabled="read_only"
+          />
         </div>
 
         <div class="flex-row">
@@ -79,9 +86,11 @@
               locale="en-ZA"
               expanded
               placeholder="Select a date"
+              :disabled="read_only"
             />
             <p class="control">
               <b-button
+                v-if="!read_only"
                 icon-left="calendar-today"
                 type="is-primary"
                 @click="$refs.stdatetimepicker.toggle()"
@@ -107,9 +116,11 @@
               locale="en-ZA"
               expanded
               placeholder="Select a date"
+              :disabled="read_only"
             />
             <p class="control">
               <b-button
+                v-if="!read_only"
                 icon-left="calendar-today"
                 type="is-primary"
                 @click="$refs.expdatetimepicker.toggle()"
@@ -131,7 +142,10 @@
                 />
               </b-tooltip>
             </template>
-            <b-select v-model="project_priority">
+            <b-select
+              v-model="project_priority"
+              :disabled="read_only"
+            >
               <option value="standard">
                 standard
               </option>
@@ -146,7 +160,10 @@
         </div>
         <div>
           <b-field>
-            <b-checkbox v-model="project_is_active">
+            <b-checkbox
+              v-model="project_is_active"
+              :disabled="read_only"
+            >
               Active
             </b-checkbox>
             <b-tooltip
@@ -183,9 +200,11 @@
             </template>
             <b-input
               v-model="targets[0].name"
+              :disabled="read_only"
             />
           </b-field>
           <b-field
+            v-if="!read_only"
             label="Object Search"
             style="width: 230px;"
           >
@@ -215,7 +234,10 @@
                 missing value
               </div>
             </template>
-            <RightAscensionInput v-model="targets[0].ra" />
+            <RightAscensionInput
+              v-model="targets[0].ra"
+              :disabled="read_only"
+            />
           </b-field>
 
           <b-field
@@ -228,7 +250,10 @@
                 missing value
               </div>
             </template>
-            <DeclinationInput v-model="targets[0].dec" />
+            <DeclinationInput
+              v-model="targets[0].dec"
+              :disabled="read_only"
+            />
           </b-field>
         </div>
       </template>
@@ -258,7 +283,7 @@
               <b-select
                 v-model="exposures[n-1].imtype"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
               >
                 <option value="light">
                   light
@@ -281,7 +306,7 @@
               <b-input
                 v-model="exposures[n-1].count"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 type="number"
                 min="1"
                 max="100000"
@@ -295,7 +320,7 @@
               <b-input
                 v-model="exposures[n-1].exposure"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 type="number"
                 min="0"
                 max="100000"
@@ -310,7 +335,7 @@
               <b-select
                 v-model="exposures[n-1].filter"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 style="width: 80px;"
               >
                 <option
@@ -361,7 +386,7 @@
               <b-select
                 v-model="exposures[n-1].bin"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
               >
                 <option value="optimal">
                   Optimal
@@ -380,7 +405,7 @@
               <b-select
                 v-model="exposures[n-1].zoom"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 @input="onZoomChange(n-1, exposures[n-1].zoom)"
               >
                 <option
@@ -402,7 +427,7 @@
                 :value="Number(exposures[n-1].width)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 type="number"
                 :min="minDegrees"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxDegrees * degreesToArcminutes : maxDegrees"
@@ -429,7 +454,7 @@
                 :value="Number(exposures[n-1].height)"
                 :class="getSymbol(exposures[n-1].zoom)"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 type="number"
                 :min="minDegrees"
                 :max="exposures[n-1].zoom === 'Mosaic arcmin.' ? maxDegrees * degreesToArcminutes : maxDegrees"
@@ -454,7 +479,7 @@
                 :value="Number(exposures[n-1].angle)"
                 class="angle-input"
                 size="is-small"
-                :disabled="!exposures[n-1].active"
+                :disabled="!exposures[n-1].active || read_only"
                 type="number"
                 :min="-90.0"
                 :max="90.0"
@@ -469,6 +494,7 @@
         </div>
 
         <button
+          v-if="!read_only"
           style="margin-top: 1em;"
           class="button"
           @click="newExposureRow"
@@ -488,10 +514,16 @@
         <div class="flex-row">
           <b-field label="Observing Side">
             <b-field>
-              <b-checkbox v-model="ascending">
+              <b-checkbox
+                v-if="!read_only"
+                v-model="ascending"
+              >
                 Ascending
               </b-checkbox>
-              <b-checkbox v-model="descending">
+              <b-checkbox
+                v-if="!read_only"
+                v-model="descending"
+              >
                 Descending
               </b-checkbox>
             </b-field>
@@ -504,8 +536,12 @@
               v-model="ra_offset"
               style="max-width: 100px"
               class="project-input"
+              :disabled="read_only"
             />
-            <b-select v-model="ra_offset_units">
+            <b-select
+              v-model="ra_offset_units"
+              :disabled="read_only"
+            >
               <option value="deg">
                 deg
               </option>
@@ -522,8 +558,12 @@
               v-model="dec_offset"
               style="max-width: 100px"
               class="project-input"
+              :disabled="read_only"
             />
-            <b-select v-model="dec_offset_units">
+            <b-select
+              v-model="dec_offset_units"
+              :disabled="read_only"
+            >
               <option value="deg">
                 deg
               </option>
@@ -542,8 +582,12 @@
               type="number"
               min="-360"
               max="360"
+              :disabled="read_only"
             />
-            <b-select value="deg">
+            <b-select
+              value="deg"
+              :disabled="read_only"
+            >
               <option value="deg">
                 deg
               </option>
@@ -564,6 +608,7 @@
               step="0.5"
               min="0"
               max="12"
+              :disabled="read_only"
             />
             <p class="control">
               <span class="button is-static">hours</span>
@@ -582,6 +627,7 @@
               step="0.1"
               min="0"
               max="7.5"
+              :disabled="read_only"
             />
             <p class="control">
               <span class="button is-static">deg</span>
@@ -601,6 +647,7 @@
               type="number"
               min="1"
               max="5"
+              :disabled="read_only"
             />
           </b-field>
           <b-field
@@ -614,6 +661,7 @@
               type="number"
               min="0"
               max="360"
+              :disabled="read_only"
             />
             <p class="control">
               <span class="button is-static">deg</span>
@@ -630,6 +678,7 @@
               type="number"
               min="0"
               max="100"
+              :disabled="read_only"
             />
             <p class="control">
               <span class="button is-static">%</span>
@@ -639,27 +688,42 @@
 
         <div style="height: 5px;" />
         <b-field>
-          <b-checkbox v-model="frequent_autofocus">
+          <b-checkbox
+            v-model="frequent_autofocus"
+            :disabled="read_only"
+          >
             Autofocus: focus more frequently
           </b-checkbox>
         </b-field>
         <b-field>
-          <b-checkbox v-model="prefer_bessell">
+          <b-checkbox
+            v-model="prefer_bessell"
+            :disabled="read_only"
+          >
             Prefer Bessell
           </b-checkbox>
         </b-field>
         <b-field>
-          <b-checkbox v-model="enhance_photometry">
+          <b-checkbox
+            v-model="enhance_photometry"
+            :disabled="read_only"
+          >
             Enhance Photometry
           </b-checkbox>
         </b-field>
         <b-field>
-          <b-checkbox v-model="add_center_to_mosaic">
+          <b-checkbox
+            v-model="add_center_to_mosaic"
+            :disabled="read_only"
+          >
             Add center to mosaic
           </b-checkbox>
         </b-field>
         <b-field>
-          <b-checkbox v-model="dark_sky_setting">
+          <b-checkbox
+            v-model="dark_sky_setting"
+            :disabled="read_only"
+          >
             Astronomical Dark & Moon Alt &lt; 6
           </b-checkbox>
         </b-field>
@@ -668,7 +732,10 @@
           style="margin-top: 1em; gap: 3em;"
         >
           <b-field label="Defocus (mags)">
-            <b-select v-model="defocus">
+            <b-select
+              v-model="defocus"
+              :disabled="read_only"
+            >
               <option
                 v-for="i in 7"
                 :key="i - 1"
@@ -680,7 +747,10 @@
           </b-field>
           <div style="padding-top: 1em;">
             <b-field>
-              <b-checkbox v-model="smart_stack">
+              <b-checkbox
+                v-model="smart_stack"
+                :disabled="read_only"
+              >
                 Smart Stack
               </b-checkbox>
               <b-tooltip
@@ -696,7 +766,10 @@
             </b-field>
 
             <b-field>
-              <b-checkbox v-model="long_stack">
+              <b-checkbox
+                v-model="long_stack"
+                :disabled="read_only"
+              >
                 Long Stack
               </b-checkbox>
               <b-tooltip
@@ -713,7 +786,10 @@
           </div>
           <div style="padding-top: 1em;">
             <b-field>
-              <b-checkbox v-model="deplete">
+              <b-checkbox
+                v-model="deplete"
+                :disabled="read_only"
+              >
                 Deplete
               </b-checkbox>
               <b-tooltip
@@ -729,7 +805,10 @@
             </b-field>
 
             <b-field>
-              <b-checkbox v-model="cycle">
+              <b-checkbox
+                v-model="cycle"
+                :disabled="read_only"
+              >
                 Cycle
               </b-checkbox>
               <b-tooltip
@@ -748,7 +827,10 @@
       </template>
     </CollapsableSection>
 
-    <div class="project-form-footer">
+    <div
+      :v-if="!read_only"
+      class="project-form-footer"
+    >
       <b-tooltip
         v-if="cloning_existing_project"
         :active="!$auth.isAuthenticated"
@@ -826,7 +908,7 @@ const mapStateToComputed = (vuexModule, propertyNames) => {
 
 export default {
   name: 'CreateProjectForm',
-  props: ['sitecode', 'project_to_load'],
+  props: { sitecode: { type: String }, project_to_load: { type: Object }, read_only: { type: Boolean, default: false } },
   mixins: [target_names, user_mixin],
   components: {
     RightAscensionInput,

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -505,8 +505,10 @@
       </template>
     </CollapsableSection>
 
-    <!-- Advanced Options-->
-    <CollapsableSection closed>
+    <!-- Advanced Options - set to open when we're in read-only mode-->
+    <CollapsableSection
+      :closed="!read_only"
+    >
       <template #header>
         Advanced Options
       </template>
@@ -828,7 +830,7 @@
     </CollapsableSection>
 
     <div
-      :v-if="!read_only"
+      v-if="!read_only"
       class="project-form-footer"
     >
       <b-tooltip

--- a/src/components/projects/ProjectSitesSelector.vue
+++ b/src/components/projects/ProjectSitesSelector.vue
@@ -22,6 +22,7 @@
         class="site-dropdown"
         multiple
         scrollable
+        :disabled="disabled"
       >
         <template #trigger>
           <b-button
@@ -105,7 +106,8 @@
 import { mapGetters } from 'vuex'
 export default {
   props: {
-    obsId: String
+    obsId: String,
+    disabled: Boolean
   },
   computed: {
     project_sites: {

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -22,7 +22,6 @@
       default-sort-direction="desc"
       detailed
       class="my-table no-margin"
-      @click="inspectProject($event.row.project_name, $qevent.row.created_at)"
     >
       <b-table-column
         v-slot="props"
@@ -30,6 +29,15 @@
         label="project name"
       >
         {{ props.row.project_name }}
+      </b-table-column>
+
+      <b-table-column
+        v-slot="props"
+        field="project_creator.username"
+        label="user"
+        sortable
+      >
+        {{ props.row.project_creator ? props.row.project_creator.username : '' }}
       </b-table-column>
 
       <b-table-column
@@ -225,8 +233,9 @@ export default {
       const project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
       axios.post(project_endpoint, request_params).then(response => {
         const project_loader = {
-          project: response.data
+          project: response.dataqq
         }
+        this.$store.dispatch('project_params/saveProjectDraft')
         this.$emit('inspect_project', project_loader)
       }).catch(err => {
         console.warn(err)

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -229,7 +229,6 @@ export default {
         project_name,
         created_at
       }
-      // TODO: Factor this out to its own call.
       const project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
       axios.post(project_endpoint, request_params).then(response => {
         const project_loader = {

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -233,7 +233,7 @@ export default {
       const project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
       axios.post(project_endpoint, request_params).then(response => {
         const project_loader = {
-          project: response.dataqq
+          project: response.data
         }
         this.$store.dispatch('project_params/saveProjectDraft')
         this.$emit('inspect_project', project_loader)

--- a/src/components/projects/UserProjectsTable.vue
+++ b/src/components/projects/UserProjectsTable.vue
@@ -22,6 +22,7 @@
       default-sort-direction="desc"
       detailed
       class="my-table no-margin"
+      @click="inspectProject($event.row.project_name, $qevent.row.created_at)"
     >
       <b-table-column
         v-slot="props"
@@ -82,6 +83,12 @@
           @click="cloneProject(props.row.project_name, props.row.created_at)"
         >
           clone
+        </button>
+        <button
+          class="button is-info is-small mr-3"
+          @click="inspectProject(props.row.project_name, props.row.created_at)"
+        >
+          inspect
         </button>
         <button
           class="button is-danger is-small"
@@ -205,6 +212,22 @@ export default {
           is_cloned_project: true
         }
         this.$emit('load_project_form', project_loader)
+      }).catch(err => {
+        console.warn(err)
+      })
+    },
+    inspectProject (project_name, created_at) {
+      const request_params = {
+        project_name,
+        created_at
+      }
+      // TODO: Factor this out to its own call.
+      const project_endpoint = this.$store.state.api_endpoints.projects_endpoint + '/get-project'
+      axios.post(project_endpoint, request_params).then(response => {
+        const project_loader = {
+          project: response.data
+        }
+        this.$emit('inspect_project', project_loader)
       }).catch(err => {
         console.warn(err)
       })

--- a/src/components/sitepages/SiteProjects.vue
+++ b/src/components/sitepages/SiteProjects.vue
@@ -2,7 +2,9 @@
   <div class="site-projects-wrapper">
     <div>
       <b-modal
-        v-model="inspectModalActive">
+        v-model="inspectModalActive"
+        @close="closeInspectModal"
+      >
         <create-project-form
           class="create-project-form"
           :sitecode="sitecode"
@@ -22,8 +24,8 @@
       <user-projects-table
         class="user-projects-table"
         :user="user"
-        @load_project_form="load_project_form"
-        @inspect_project="inspect_project"
+        @load_project_form="loadProjectForm"
+        @inspect_project="inspectProject"
       />
 
       <div class="user-events-table">
@@ -84,17 +86,21 @@ export default {
     displayUtcTime (time) {
       return moment(time).utc().format('MMM D, kk:mm')
     },
-
     updateTime () {
       this.localTime = moment().format('MMM D, kk:mm')
       this.siteTime = moment().tz(this.timezone).format('MMM D, kk:mm')
       this.utcTime = moment().utc().format('MMM D, kk:mm')
     },
-    inspect_project (project) {
+    inspectProject (project) {
       this.project_to_load = project
       this.inspectModalActive = true
     },
-    load_project_form (project) {
+    closeInspectModal () {
+      this.inspectModalActive = false
+      // return the project params state back to where it was before we opened the modal
+      this.$store.dispatch('project_params/reloadProjectDraft')
+    },
+    loadProjectForm (project) {
       this.project_to_load = project
     },
     refreshUserEvents () {

--- a/src/components/sitepages/SiteProjects.vue
+++ b/src/components/sitepages/SiteProjects.vue
@@ -1,5 +1,16 @@
 <template>
   <div class="site-projects-wrapper">
+    <div>
+      <b-modal
+        v-model="inspectModalActive">
+        <create-project-form
+          class="create-project-form"
+          :sitecode="sitecode"
+          :project_to_load="project_to_load"
+          :read_only="true"
+        />
+      </b-modal>
+    </div>
     <create-project-form
       class="create-project-form"
       :sitecode="sitecode"
@@ -12,6 +23,7 @@
         class="user-projects-table"
         :user="user"
         @load_project_form="load_project_form"
+        @inspect_project="inspect_project"
       />
 
       <div class="user-events-table">
@@ -45,7 +57,8 @@ export default {
       siteTime: '-',
       utcTime: '-',
 
-      project_to_load: ''
+      project_to_load: '',
+      inspectModalActive: false
     }
   },
   created () {
@@ -77,7 +90,10 @@ export default {
       this.siteTime = moment().tz(this.timezone).format('MMM D, kk:mm')
       this.utcTime = moment().utc().format('MMM D, kk:mm')
     },
-
+    inspect_project (project) {
+      this.project_to_load = project
+      this.inspectModalActive = true
+    },
     load_project_form (project) {
       this.project_to_load = project
     },

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -1,4 +1,6 @@
+import Vue from 'vue'
 import moment from 'moment'
+import _ from 'lodash'
 
 const state = {
   project_window: 7, // in days, how long the project has a chance to be scheduled; this is not sent with the project
@@ -64,7 +66,8 @@ const state = {
   start_date: new Date(), // Date obj here for datetimepicker, but gets converted to moment str in UTC
   long_stack: false,
   smart_stack: true,
-  defocus: 0
+  defocus: 0,
+  draft_project_params: {} // If a user has entered some info into the project form, save it here so we can go back to it.
 }
 
 const getters = {
@@ -172,7 +175,14 @@ const mutations = {
   start_date (state, val) { state.start_date = val },
   long_stack (state, val) { state.long_stack = val },
   smart_stack (state, val) { state.smart_stack = val },
-  defocus (state, val) { state.defocus = val }
+  defocus (state, val) { state.defocus = val },
+  draft_project_params (state, val) { state.draft_project_params = val }, // project params that have saved off in saveProjectDraft
+  rewrite_state (state, val) {
+    // loop through and rewrite the state
+    for (const stateItem in val) {
+      Vue.set(state, stateItem, val[stateItem])
+    }
+  }
 }
 
 const actions = {
@@ -257,6 +267,18 @@ const actions = {
     }
     commit('start_date', moment(project.project_constraints.start_date).toDate())
     commit('expiry_date', moment(project.project_constraints.expiry_date).toDate())
+  },
+  saveProjectDraft ({ state, commit }) {
+    // make a deep copy of the current draft of the project params, without the project params
+    const stateCopy = _.cloneDeep(state)
+    stateCopy.draft_project_params = {}
+    commit('draft_project_params', stateCopy)
+  },
+  reloadProjectDraft ({ state, commit }) {
+    // make a deep copy of the project params and load into the current state
+    const projectParamsCopy = _.cloneDeep(state.draft_project_params)
+    commit('rewrite_state', projectParamsCopy)
+    commit('draft_project_params', {})
   }
 }
 

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -269,7 +269,7 @@ const actions = {
     commit('expiry_date', moment(project.project_constraints.expiry_date).toDate())
   },
   saveProjectDraft ({ state, commit }) {
-    // make a deep copy of the current draft of the project params, without the project params
+    // make a deep copy of the current state of the project params, without draft project params
     const stateCopy = _.cloneDeep(state)
     stateCopy.draft_project_params = {}
     commit('draft_project_params', stateCopy)


### PR DESCRIPTION
This PR adds an "inspect" button to the projects table, which opens up a read-only view of the CreateProjectForm, pre-populated with the data that needs to be displayed.

_RightAscensionInput/DeclinationInput/ProjectSitesSelector:_
* Add "disabled" prop so the underlying input fields may be disabled

_CreateProjectForm_
* Go through and conditionally disable each input/field/checkbox if the form is read-only
* Adjust the props to have defaults so we can set read-only to false by default

_UserProjectsTable_
* Add "inspect" button to table row, which fetches the project, saves whatever is currently entered into the form into the store to be reloaded after the inspector is closed, and emits an `inspect-project` signal along with the project data for the so the parent SiteProjects component can pop up and render the modal.
* Add username as column, make sortable

_SiteProjects_
* Add modal that is hidden by default, but will be shown and render a read-only CreateProjectsForm, with all data from the project that has been selected for inspection.

_project_params store module_
* Add a `draft_project_params` store variable to hold the draft of the project that's been entered into the project form prior to the user clicking "inspect," so that they may be re-loaded when the user closes the inspection tab. Unfortunately the CreateProjectForm is tightly coupled to the vuex store and whenever we render a new instance of that component, it overwrites the data in the project_params module of the store - so we need to keep a history of anything that was entered into the form, if the user had done that.
* Add actions to both save and re-load a project draft from the store.

**Video!**

https://github.com/LCOGT/ptr_ui/assets/7182533/43fde863-91c5-4560-8500-927f069266da

