### PR TITLE
Feature/project requests

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -704,8 +704,21 @@
               <span class="button is-static">%</span>
             </p>
           </b-field>
+          <b-field label="Defocus (mags)">
+            <b-select
+              v-model="defocus"
+              :disabled="read_only"
+            >
+              <option
+                v-for="i in 7"
+                :key="i - 1"
+                :value="i - 1"
+              >
+                {{ i - 1 }}
+              </option>
+            </b-select>
+          </b-field>
         </div>
-
         <div style="height: 5px;" />
         <b-field>
           <b-checkbox
@@ -751,20 +764,6 @@
           class="flex-row"
           style="margin-top: 1em; gap: 3em;"
         >
-          <b-field label="Defocus (mags)">
-            <b-select
-              v-model="defocus"
-              :disabled="read_only"
-            >
-              <option
-                v-for="i in 7"
-                :key="i - 1"
-                :value="i - 1"
-              >
-                {{ i - 1 }}
-              </option>
-            </b-select>
-          </b-field>
           <div style="padding-top: 1em;">
             <b-field>
               <b-checkbox

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -646,7 +646,7 @@
               type="number"
               step="0.5"
               min="0"
-              max="10"
+              max="24"
               :disabled="read_only"
             />
             <p class="control">

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -635,6 +635,24 @@
               <span class="button is-static">deg</span>
             </p>
           </b-field>
+          <b-field
+            label="Max Night Duration"
+            :type="{'is-danger': warn.max_night_duration}"
+          >
+            <b-input
+              v-model="max_night_duration"
+              class="project-input"
+              style="max-width: 150px;"
+              type="number"
+              step="0.5"
+              min="0"
+              max="10"
+              :disabled="read_only"
+            />
+            <p class="control">
+              <span class="button is-static">hours</span>
+            </p>
+          </b-field>
         </div>
 
         <div class="flex-row">
@@ -1455,6 +1473,7 @@ export default {
       'position_angle',
       'max_ha',
       'min_zenith_dist',
+      'max_night_duration',
       'max_airmass',
       'lunar_dist_min',
       'lunar_phase_max',

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -50,7 +50,7 @@ const state = {
   position_angle: 0,
   max_ha: 4, // decimal hours
   min_zenith_dist: 0, // degrees
-  max_airmass: 2.0,
+  max_airmass: 3.0,
   lunar_dist_min: 30, // deg
   lunar_phase_max: 60, // %
   frequent_autofocus: false,

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -50,6 +50,7 @@ const state = {
   position_angle: 0,
   max_ha: 4, // decimal hours
   min_zenith_dist: 0, // degrees
+  max_night_duration: 6, // hours
   max_airmass: 3.0,
   lunar_dist_min: 30, // deg
   lunar_phase_max: 60, // %
@@ -84,6 +85,7 @@ const getters = {
       position_angle: state.position_angle,
       max_ha: state.max_ha,
       min_zenith_dist: state.min_zenith_dist,
+      max_night_duration: state.max_night_duration,
       max_airmass: state.max_airmass,
       lunar_dist_min: state.lunar_dist_min,
       lunar_phase_max: state.lunar_phase_max,
@@ -159,6 +161,7 @@ const mutations = {
   position_angle (state, val) { state.position_angle = val },
   max_ha (state, val) { state.max_ha = val },
   min_zenith_dist (state, val) { state.min_zenith_dist = val },
+  max_night_duration (state, val) { state.max_night_duration = val },
   max_airmass (state, val) { state.max_airmass = val },
   lunar_dist_min (state, val) { state.lunar_dist_min = val },
   lunar_phase_max (state, val) { state.lunar_phase_max = val },
@@ -222,6 +225,7 @@ const actions = {
     commit('position_angle', 0)
     commit('max_ha', 4) // decimal hrs
     commit('min_zenith_dist', 0) // deg
+    commit('max_night_duration', 6) // hours
     commit('max_airmass', 2.0)
     commit('lunar_dist_min', 30) // deg
     commit('lunar_phase_max', 60) // %


### PR DESCRIPTION
## FEATURE: Some project requests

**Background:**
Wayne made some requests [here](https://lcogt.slack.com/archives/CLAQ9U79B/p1708477319272579) to change and add some of the advanced options in the Projects tab.

**Implementation**
For the first request, it was quite simple to change the default.
The second request followed the implementation of `min_zenith_dist`. So I added it to the store, added a getter, added a mutation, and added an action in `project_params`. I set the default value to 6 hours, the min to 0, the max to 24, and the step of 0.5. That's it!
The last request just required moving the existing field elsewhere. No logic changed


### Visuals
**Screenshot of the project form with updated requests**
<img width="1715" alt="Screenshot 2024-02-21 at 4 03 38 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/8d8a03a8-0903-4b35-9918-b6fa3ba075c9">

**Screen recording of the store updating the new state of `max night duration`**

https://github.com/LCOGT/ptr_ui/assets/54489472/3a4e47fa-f397-4ffb-adb5-325ef08f1ca0

