### PR TITLE
Feature/display skymap values

### DIFF
--- a/src/components/sitepages/SiteHome.vue
+++ b/src/components/sitepages/SiteHome.vue
@@ -43,14 +43,6 @@
       <a href="https://www.cleardarksky.com/c/LmyRdgObNMkey.html">
         <img src="https://www.cleardarksky.com/c/LmyRdgObNMcsk.gif?c=1594801"></a>
     </div>
-    <div
-      v-if="sitecode.toLowerCase()=='sro'"
-      class="level"
-    >
-      <a href="https://www.cleardarksky.com/c/SROCAkey.html">
-        <img src="https://www.cleardarksky.com/c/SROCAcsk.gif?c=1076447"></a>
-    </div>
-
     <div style="height: 2em;" />
 
     <OWMReport v-if="userIsAdmin" />

--- a/src/components/sitepages/SiteHome.vue
+++ b/src/components/sitepages/SiteHome.vue
@@ -43,6 +43,14 @@
       <a href="https://www.cleardarksky.com/c/LmyRdgObNMkey.html">
         <img src="https://www.cleardarksky.com/c/LmyRdgObNMcsk.gif?c=1594801"></a>
     </div>
+    <div
+      v-if="sitecode.toLowerCase()=='sro'"
+      class="level"
+    >
+      <a href="https://www.cleardarksky.com/c/SROCAkey.html">
+        <img src="https://www.cleardarksky.com/c/SROCAcsk.gif?c=1076447"></a>
+    </div>
+
     <div style="height: 2em;" />
 
     <OWMReport v-if="userIsAdmin" />

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -1171,7 +1171,7 @@ $toggle-button-height: 32px;
     }
 }
 .sidebar-tab-content {
-    padding: 1em;
+    padding: 0.5em;
     background-color: $background;
 }
 

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -1171,7 +1171,7 @@ $toggle-button-height: 32px;
     }
 }
 .sidebar-tab-content {
-    padding: 0.5em;
+    padding: 1em;
     background-color: $background;
 }
 

--- a/src/components/status/SiteStatusFooter.vue
+++ b/src/components/status/SiteStatusFooter.vue
@@ -386,6 +386,7 @@ export default {
       'azimuth',
       'altitude',
       'airmass',
+      'transition_time',
       'refraction',
       'zenith_distance',
 
@@ -467,6 +468,7 @@ export default {
         spacer,
         this.hour_angle,
         this.airmass,
+        this.transition_time,
         this.zenith_distance,
         this.refraction
       ]

--- a/src/components/status/SiteStatusFooter.vue
+++ b/src/components/status/SiteStatusFooter.vue
@@ -387,6 +387,7 @@ export default {
       'altitude',
       'airmass',
       'transition_time',
+      'transition_airmass',
       'refraction',
       'zenith_distance',
 
@@ -469,6 +470,7 @@ export default {
         this.hour_angle,
         this.airmass,
         this.transition_time,
+        this.transition_airmass,
         this.zenith_distance,
         this.refraction
       ]

--- a/src/store/modules/sitestatus/getters/accumulated_getters.js
+++ b/src/store/modules/sitestatus/getters/accumulated_getters.js
@@ -27,6 +27,7 @@ const buildTelescopeTabStatus1Shorter = (state, getters) => {
   if (getters.azimuth.val != '-') { status.push({ ...getters.azimuth, name: 'Az' }) }
   if (getters.altitude.val != '-') { status.push({ ...getters.altitude, name: 'Alt' }) }
   if (getters.refraction.val != '-') { status.push({ ...getters.refraction, name: 'Refr.' }) }
+  if (getters.transition_time.val != '-') { status.push({ ...getters.transition_time, name: 'Trans. Time' }) }
   return status
 }
 

--- a/src/store/modules/sitestatus/getters/accumulated_getters.js
+++ b/src/store/modules/sitestatus/getters/accumulated_getters.js
@@ -28,6 +28,7 @@ const buildTelescopeTabStatus1Shorter = (state, getters) => {
   if (getters.altitude.val != '-') { status.push({ ...getters.altitude, name: 'Alt' }) }
   if (getters.refraction.val != '-') { status.push({ ...getters.refraction, name: 'Refr.' }) }
   if (getters.transition_time.val != '-') { status.push({ ...getters.transition_time, name: 'Trans. Time' }) }
+  if (getters.transition_airmass.val != '-') { status.push({ ...getters.transition_airmass, name: 'Trans. Airmass' }) }
   return status
 }
 

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -55,9 +55,16 @@ const airmass = (state, getters) => {
 }
 
 const transition_time = (state, getters) => {
-  const name = 'Transit. Time'
+  const name = 'Trans. Time'
   const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
   const is_stale = isItemStale(getters, 'mount_state', 'transit_time')
+  return { name, val, is_stale }
+}
+
+const transition_airmass = (state, getters) => {
+  const name = 'Trans. Airmass'
+  const val = parseFloat(getters.mount_state.transition_airmass?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'transition_airmass')
   return { name, val, is_stale }
 }
 
@@ -150,6 +157,7 @@ export default {
   zenith_distance,
   airmass,
   transition_time,
+  transition_airmass,
   refraction,
   hour_angle,
   mount_state,

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -56,7 +56,7 @@ const airmass = (state, getters) => {
 
 const transition_time = (state, getters) => {
   const name = 'Trans. Time'
-  const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
+  const val = parseFloat(getters.mount_state.transition_time?.val)?.toFixed(4) ?? '-'
   const is_stale = isItemStale(getters, 'mount_state', 'transition_time')
   return { name, val, is_stale }
 }

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -54,6 +54,13 @@ const airmass = (state, getters) => {
   return { name, val, is_stale }
 }
 
+const transition_time = (state, getters) => {
+  const name = 'Transit. Time'
+  const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
+  const is_stale = isItemStale(getters, 'mount_state', 'transit_time')
+  return { name, val, is_stale }
+}
+
 const refraction = (state, getters) => {
   const name = 'Refraction'
   const val = parseFloat(getters.mount_state.refraction?.val)?.toFixed(4) ?? '-'
@@ -142,6 +149,7 @@ export default {
   sidereal_time,
   zenith_distance,
   airmass,
+  transition_time,
   refraction,
   hour_angle,
   mount_state,

--- a/src/store/modules/sitestatus/getters/mount_getters.js
+++ b/src/store/modules/sitestatus/getters/mount_getters.js
@@ -57,7 +57,7 @@ const airmass = (state, getters) => {
 const transition_time = (state, getters) => {
   const name = 'Trans. Time'
   const val = parseFloat(getters.mount_state.airmass?.val)?.toFixed(4) ?? '-'
-  const is_stale = isItemStale(getters, 'mount_state', 'transit_time')
+  const is_stale = isItemStale(getters, 'mount_state', 'transition_time')
   return { name, val, is_stale }
 }
 


### PR DESCRIPTION
## FEATURE: Display `transition time` and `airmass at transition` values

**Background:**
Wayne [made a request here](https://lcogt.slack.com/archives/CLAQ9U79B/p1709440661804119) to display a few values. `airmass` already existed so that was not necessary to implement. I chatted with him and he told me to add fields and that he would take care of getting the values. In the meantime, he wants 'NaN' displayed. 

**Implementation:**
Followed the logic of what the rest of the fields in Site status footer were doing. What I'm not sure of, is if the value itself will be a number and if it makes sense to parse it and fix it. But in the meantime, this can remain as is and it returns 'NaN'. 


### VISUALS
**On the right, you can see the 2 new values `trans. time` and `trans. airmass`**
<img width="1727" alt="Screenshot 2024-03-18 at 11 04 51 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/c9a91250-d5d0-4c50-84aa-2e6094c083db">
