### PR TITLE
New script setting equatorial sweep with two numerical input fields

### DIFF
--- a/src/components/ScriptSettings/CollectScreenFlats.vue
+++ b/src/components/ScriptSettings/CollectScreenFlats.vue
@@ -6,6 +6,7 @@
           <b-numberinput
             v-model="numFrames"
             type="is-light"
+            size="is-small"
             controls-position="compact"
             min="0"
             max="63"

--- a/src/components/ScriptSettings/CollectSkyFlats.vue
+++ b/src/components/ScriptSettings/CollectSkyFlats.vue
@@ -6,6 +6,7 @@
           <b-numberinput
             v-model="numFrames"
             type="is-light"
+            size="is-small"
             controls-position="compact"
             min="0"
           />

--- a/src/components/ScriptSettings/EquatorialSweep.vue
+++ b/src/components/ScriptSettings/EquatorialSweep.vue
@@ -1,0 +1,53 @@
+<template>
+  <section>
+    <div class="field-group">
+      <b-field label="Points">
+        <b-numberinput
+          v-model="points"
+          type="is-light"
+          controls-position="compact"
+          min="0"
+        />
+      </b-field>
+      <b-field label="Minimum Altitude">
+        <b-numberinput
+          v-model="minAltitude"
+          type="is-light"
+          controls-position="compact"
+          min="0"
+        />
+      </b-field>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  computed: {
+
+    points: {
+      get () { return this.$store.state.scriptSettings.equatorialSweep.points },
+      set (value) {
+        const scriptName = 'equatorialSweep'
+        const paramName = 'points'
+        this.$store.commit('scriptSettings/updateScriptParam', { scriptName, paramName, value })
+      }
+    },
+    minAltitude: {
+      get () { return this.$store.state.scriptSettings.equatorialSweep.minAltitude },
+      set (value) {
+        const scriptName = 'equatorialSweep'
+        const paramName = 'minAltitude'
+        this.$store.commit('scriptSettings/updateScriptParam', { scriptName, paramName, value })
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.field-group {
+    padding-right: 2em;
+    padding-bottom: 1em;
+}
+</style>

--- a/src/components/ScriptSettings/EquatorialSweep.vue
+++ b/src/components/ScriptSettings/EquatorialSweep.vue
@@ -5,6 +5,7 @@
         <b-numberinput
           v-model="points"
           type="is-light"
+          size="is-small"
           controls-position="compact"
           min="0"
         />
@@ -13,6 +14,7 @@
         <b-numberinput
           v-model="minAltitude"
           type="is-light"
+          size="is-small"
           controls-position="compact"
           min="0"
         />

--- a/src/components/ScriptSettings/PointingRun.vue
+++ b/src/components/ScriptSettings/PointingRun.vue
@@ -4,7 +4,8 @@
       <b-field label="No. of Pointings">
         <b-numberinput
           v-model="numPointingRuns"
-          type="is-dark"
+          type="is-light"
+          size="is-small"
           controls-position="compact"
           min="1"
           max="10000"
@@ -15,7 +16,8 @@
       <b-field label="Min. Altitude (deg)">
         <b-numberinput
           v-model="minAltitude"
-          type="is-dark"
+          type="is-light"
+          size="is-small"
           controls-position="compact"
           min="0"
           max="90"

--- a/src/components/ScriptSettings/ScriptSettings.vue
+++ b/src/components/ScriptSettings/ScriptSettings.vue
@@ -32,6 +32,7 @@ import TakeLunarStack from '@/components/ScriptSettings/TakeLunarStack'
 import PointingRun from '@/components/ScriptSettings/PointingRun'
 import FocusAuto from '@/components/ScriptSettings/FocusAuto'
 import EstimateFocusOffset from './EstimateFocusOffset.vue'
+import EquatorialSweep from './EquatorialSweep.vue'
 import FocusExtensive from '@/components/ScriptSettings/FocusExtensive'
 import FocusFine from '@/components/ScriptSettings/FocusFine'
 export default {
@@ -49,6 +50,7 @@ export default {
     PointingRun,
     FocusAuto,
     EstimateFocusOffset,
+    EquatorialSweep,
     FocusExtensive,
     FocusFine
   },

--- a/src/components/ScriptSettings/TakeLunarStack.vue
+++ b/src/components/ScriptSettings/TakeLunarStack.vue
@@ -6,6 +6,7 @@
           <b-numberinput
             v-model="numFrames"
             type="is-light"
+            size="is-small"
             controls-position="compact"
             min="0"
           />

--- a/src/components/ScriptSettings/TakePlanetStack.vue
+++ b/src/components/ScriptSettings/TakePlanetStack.vue
@@ -6,6 +6,7 @@
           <b-numberinput
             v-model="numFrames"
             type="is-light"
+            size="is-small"
             controls-position="compact"
             min="0"
           />

--- a/src/store/modules/scriptSettings.js
+++ b/src/store/modules/scriptSettings.js
@@ -20,6 +20,10 @@ const state = {
     bin: 1, // integer: 1, 2, or 4
     area: '100%' // percent, from 0 to 1
   },
+  equatorialSweep: {
+    points: 12,
+    minAltitude: 30
+  },
   focusExtensive: {
     target: 'near_tycho_star', // alternative: 'use_field'
     bin: 1, // integer: 1, 2, or 4
@@ -90,6 +94,7 @@ const state = {
   scriptsWithSettings: [
     'focusAuto',
     'estimateFocusOffset',
+    'equatorialSweep',
     'focusExtensive',
     'focusFine',
     'restackLocalCalibrations',
@@ -108,6 +113,7 @@ const state = {
   readableScriptNames: {
     focusAuto: 'Auto Focus',
     estimateFocusOffset: 'Estimate Focus Offset',
+    equatorialSweep: 'Equatorial Sweep',
     focusExtensive: 'Extensive Focus',
     focusFine: 'Fine Focus',
     restackLocalCalibrations: 'Restack Local Calibrations',
@@ -296,6 +302,12 @@ const actions = {
           target: 'near_tycho_star', // alternative: 'use_field'
           bin: 1, // integer: 1, 2, or 4
           area: '100%' // percent, from 0 to 1
+        }
+      },
+      equatorialSweep () {
+        return {
+          points: 12,
+          minAltitude: 30
         }
       },
       focusExtensive () {


### PR DESCRIPTION
Per Wayne's request, new script field for Equatorial Sweeps. Min 0 for both, max none, default to 12 and 30.

<img width="722" alt="Screenshot 2024-03-19 at 11 57 04 AM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/98de1df4-8c51-47b5-b3b5-f58179ed5223">
