### PR TITLE
Fix/min exposure

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -322,7 +322,7 @@
                 size="is-small"
                 :disabled="!exposures[n-1].active || read_only"
                 type="number"
-                min="0"
+                min="0.000001"
                 max="100000"
                 step="any"
               />

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -324,10 +324,8 @@
                 type="number"
                 min="0"
                 max="100000"
+                step="any"
               />
-              <p class="control">
-                <span class="button is-static is-small">s</span>
-              </p>
             </b-field>
             <b-field
               :label="n==1 ? 'Filter' : ''"
@@ -1090,7 +1088,6 @@ export default {
         return index === indexToMatch ? { ...obj, [key]: val } : obj
       })
     },
-
     clearProjectForm () {
       this.modifying_existing_project = false
       this.cloning_existing_project = false


### PR DESCRIPTION
## QUICK FIX: Minimum exposure


Michael discovered that users cannot input decimals for exposures. This was quickly changed by changing the `min` value of the Exposure field to be `0.000001` and having a step of `any`. This step defaults to 1 but if the user wants to manually input something else, then that can be done too.