### PR TITLE
Do not render email addresses for anonymous users

### DIFF
--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -130,7 +130,7 @@ import resourceTimeGridPlugin from '@fullcalendar/resource-timegrid'
 import bootstrapPlugin from '@fullcalendar/bootstrap'
 import momentTimezonePlugin from '@fullcalendar/moment-timezone'
 
-import { makeUniqueID, copyFcEvent, convertFullCalendarEventToPtrFormat, convertEventEditorResponseToPtrFormat, getMoonPhaseDays, rgba_from_illumination, oneDayTwilight } from '@/utils/calendar_utils.js'
+import { makeUniqueID, copyFcEvent, convertFullCalendarEventToPtrFormat, convertEventEditorResponseToPtrFormat, getMoonPhaseDays, rgba_from_illumination, oneDayTwilight, removeSensitiveData } from '@/utils/calendar_utils.js'
 
 // must manually include stylesheets for each plugin
 import '@fullcalendar/core/main.css'
@@ -273,7 +273,8 @@ export default {
     ...mapState('user_data', [
       'all_projects',
       'userId',
-      'userIsAuthenticated'
+      'userIsAuthenticated',
+      'userIsAdmin'
     ]),
     ...mapGetters('sitestatus', [
       'forecast'
@@ -406,6 +407,11 @@ export default {
   },
 
   methods: {
+
+    // Only show email address on objects where the user is an Admin or is the creator of the object
+    showEmail (obj) {
+      return this.userIsAdmin || obj.creator_id === this.userId
+    },
 
     // This is connected to the < button in the calendar header left
     incrementDateBack () {
@@ -1141,9 +1147,9 @@ export default {
           start: obj.start,
           end: obj.end,
           id: obj.event_id,
-          title: obj.title,
+          title: removeSensitiveData(obj.title, this.showEmail(obj)),
           reservation_type: obj.reservation_type,
-          creator: obj.creator,
+          creator: removeSensitiveData(obj.creator, this.showEmail(obj)),
           creator_id: obj.creator_id,
           site: obj.site,
           resourceId: obj.resourceId,

--- a/src/utils/calendar_utils.js
+++ b/src/utils/calendar_utils.js
@@ -1,6 +1,18 @@
 import moment from 'moment'
 import SunCalc from 'suncalc'
 
+// Make sure we don't display sensitive data (e.g. email addresses) in the public calendar 
+const removeSensitiveData = (string, showEmail) =>
+{
+  // conditionally show email if the user is an admin or the owner of a block
+  if (showEmail) {
+    return string
+  }
+  else {
+    return string.split('@')[0]
+  }
+}
+
 // Make a unique id for calendar events. UUID style. This is the pk in dynamodb.
 const makeUniqueID = () => {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (
@@ -238,6 +250,7 @@ const oneDayTwilight = (timestamp, latitude, longitude) => {
 }
 
 export {
+  removeSensitiveData,
   makeUniqueID,
   copyFcEvent,
   convertFullCalendarEventToPtrFormat,

--- a/src/utils/calendar_utils.js
+++ b/src/utils/calendar_utils.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import SunCalc from 'suncalc'
 
-// Make sure we don't display sensitive data (e.g. email addresses) in the public calendar 
+// Make sure we don't display sensitive data (e.g. email addresses) in the public calendar
 const removeSensitiveData = (string, showEmail) =>
 {
   // conditionally show email if the user is an admin or the owner of a block


### PR DESCRIPTION
This is based off a request from Michael to not show email addresses to non-admin users.

The only users that should be able to see any sort of email address are the users that own the calendar block or an admin.

User as admin:

<img width="589" alt="image" src="https://github.com/LCOGT/ptr_ui/assets/7182533/b29b2558-05e1-4b11-8cf0-5446399ce93c">
<img width="508" alt="Screenshot 2024-04-01 at 11 12 30 AM" src="https://github.com/LCOGT/ptr_ui/assets/7182533/2253dfdb-3a46-4661-b0cf-65ba3b353733">

Anonymous user:

<img width="364" alt="image" src="https://github.com/LCOGT/ptr_ui/assets/7182533/4c0ccbc9-a627-49b9-9c9f-b7336baed6fa">
<img width="505" alt="image" src="https://github.com/LCOGT/ptr_ui/assets/7182533/c6702f79-dc24-4554-8865-2647f035a7dd">
