### PR TITLE
fix to overflow on exposure panel in create project form

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -271,11 +271,7 @@
             :key="n"
             class="exposure-row"
           >
-            <b-field
-              :label="n==1 ? '  ' : ' '"
-            >
-              <b-checkbox v-model="exposures[n-1].active" />
-            </b-field>
+            <b-checkbox v-model="exposures[n-1].active" />
             <b-field
               size="is-small"
               :label="n==1 ? 'Imtype' : ''"
@@ -1574,11 +1570,16 @@ export default {
     margin-top: 1em;
 }
 .exposure-row {
+    display: flex;
     white-space: nowrap;
 }
 .exposure-row > * {
     margin-right: 8px;
     display: inline-block;
+}
+.exposure-row:first-child .b-checkbox {
+  /* Since checkboxes don't have a label this shifts the first checkbox down */
+  margin-top: 20px
 }
 .flex-row {
     display: flex;


### PR DESCRIPTION
Fixed some overflow by changing display to flex and removing code that was trying to insert a white space label to fix the spacing of the check-boxes. Instead added a CSS selector for the first checkbox and shifted it down. 

**Before**
<img width="1097" alt="Screenshot 2024-04-10 at 3 59 00 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/49a59d68-7b60-4bc2-8a05-5aab32a1b620">
**After**
<img width="1093" alt="Screenshot 2024-04-11 at 12 54 39 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/35b42a81-add2-4753-b1e1-2d9ac64ed3a0">