### PR TITLE
Nightlog appearance adjustment

### DIFF
--- a/src/components/NightLog.vue
+++ b/src/components/NightLog.vue
@@ -5,11 +5,10 @@
         <b-button
           :disabled="!noteIsLoaded && !noteIsExpired"
           class="is-warning is-small"
-          :class="buttonAnimating ? 'note-is-animating' : ''"
           :size="noteButtonSize"
           @click="$event => { noteVisible = true; editorVisible = false }"
         >
-          night log
+          Night Log
         </b-button>
       </p>
       <p
@@ -17,13 +16,10 @@
         class="control"
       >
         <b-button
-          class="is-warning is-small"
-          outlined
+          class="is-small"
           icon-left="plus"
           @click="$event => { editorVisible = true; noteVisible = false }"
-        >
-          new
-        </b-button>
+        />
       </p>
     </b-field>
 
@@ -237,19 +233,9 @@ export default {
         this.note = ''
       })
     },
-    pulseNightlogButton () {
-      // Quick animation to show where the user can reopen the night log
-      this.buttonAnimating = true
-      this.noteButtonSize = 'is-medium'
-      setTimeout(() => { this.noteButtonSize = 'is-small' }, 200)
-      setTimeout(() => { this.buttonAnimating = false }, 1600)
-    },
     messageCloseHandler () {
       // mark the message as read
       window.localStorage.setItem(this.nightlogReadId, this.noteId)
-
-      // animate the button users need to reopen
-      this.pulseNightlogButton()
     }
   },
   computed: {
@@ -305,7 +291,6 @@ export default {
 .note-container {
     position: absolute;
     width: 350px;
-    margin-top: 1.5em;
     margin-left: -280px; // right side should align with right of "night log" button (which is 70px wide)
 
     z-index: 40; // same as buefy modal windows
@@ -336,9 +321,6 @@ export default {
 
 .note-expires-soon-warning {
   color: grey;
-}
-.note-is-animating {
-  transition: 0.2s;
 }
 
 </style>

--- a/src/components/sitepages/SiteData.vue
+++ b/src/components/sitepages/SiteData.vue
@@ -35,17 +35,7 @@
 
       <!-- Collapsible panels on the right of the image -->
       <div class="image-tools-area">
-        <div
-          class="obs-config-box"
-          style="padding-bottom: calc(1em - 11.25px); justify-content: space-between;"
-        >
-          <!--
-            <UiSyncControls />
-            <div style="width: 1px; height: 30px; border-left: 1px solid grey; margin: 0 1em;" />
-          -->
-          <NightLog :site="sitecode" />
-        </div>
-
+        <NightLog :site="sitecode" />
         <b-tabs v-model="active_image_tools_tab">
           <b-tab-item
             label="controls"


### PR DESCRIPTION
Nightlog button took up a lot of space with its own section, wanted to reduce its profile. Also had a anti-css way of animating closing which wasn't needed.

Before
<img width="895" alt="Screenshot 2024-04-11 at 2 06 39 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/5ac9498e-31df-467d-8d3b-8d36d9055b0e">
After
<img width="880" alt="Screenshot 2024-04-11 at 2 06 48 PM" src="https://github.com/LCOGT/ptr_ui/assets/54085254/5070badd-b54f-4f7f-b397-769fc7087010">
