### PR TITLE
set sub_stack to be default to on since its prefered

### DIFF
--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -20,7 +20,7 @@ const state = {
 
   // Stack parameters
   smartstackIsActive: true,
-  subStackIsActive: false,
+  subStackIsActive: true,
 
   // Subframe parameters
   subframeIsActive: false,

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -252,7 +252,7 @@ const actions = {
     commit('start_date', start_date)
 
     commit('smart_stack', true)
-    commit('sub_stack', false)
+    commit('sub_stack', true)
     commit('defocus', 0)
   },
   loadProject ({ state, commit }, project) {


### PR DESCRIPTION
changes Sub stack to be defaulted to 'on' in the camera and project settings. Changed command params which is the default state for fields and changed the value in resetProjectForm so that when the project form is reset it will be true.
