### PR TITLE
Fix/project values

### DIFF
--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -659,7 +659,7 @@
               v-model="max_airmass"
               class="project-input"
               type="number"
-              min="0"
+              min="1"
               max="5"
               step="0.01"
               :disabled="read_only"

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -659,9 +659,11 @@
               v-model="max_airmass"
               class="project-input"
               type="number"
-              min="1"
+              min="0"
               max="5"
+              step="0.01"
               :disabled="read_only"
+              @blur="roundMaxAirmass"
             />
           </b-field>
           <b-field
@@ -1068,6 +1070,12 @@ export default {
       'resetProjectForm',
       'loadProject'
     ]),
+    roundMaxAirmass () {
+      const roundedValue = parseFloat(this.max_airmass).toFixed(2)
+      console.log('roundedValue', roundedValue)
+      this.$store.commit('project_params/max_airmass', roundedValue)
+      this.setDelayedError()
+    },
     // Set store value for min_zenith_dist if it exists in mount config
     load_default_zenith_from_mount () {
       this.$store.commit('project_params/min_zenith_dist', this.selected_mount_config?.default_zenith_avoid ?? 0)
@@ -1485,7 +1493,6 @@ export default {
       'defocus'
     ]),
     ...mapGetters('project_params', ['project_constraints', 'projectToSend']),
-
     // Filter dropdown choices update based on which sites are selected.
     project_filter_list () {
       const selected_sites = this.project_sites.flat(Infinity)

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -661,7 +661,7 @@
               type="number"
               min="1"
               max="5"
-              step="0.01"
+              step="0.0001"
               :disabled="read_only"
               @blur="roundMaxAirmass"
             />

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1072,9 +1072,7 @@ export default {
     ]),
     roundMaxAirmass () {
       const roundedValue = parseFloat(this.max_airmass).toFixed(2)
-      console.log('roundedValue', roundedValue)
       this.$store.commit('project_params/max_airmass', roundedValue)
-      this.setDelayedError()
     },
     // Set store value for min_zenith_dist if it exists in mount config
     load_default_zenith_from_mount () {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1304,18 +1304,18 @@ export default {
 
     // Getting width for 'Full' zoom selection
     getFullWidth () {
-      const size_x = this.camera_size_x
-      const pix = this.pixel_scale
-      if (size_x && pix) {
-        return (size_x * pix) / 3600
-      } else return 1
-    },
-    // Getting height for 'Full' zoom selection
-    getFullHeight () {
       const size_y = this.camera_size_y
       const pix = this.pixel_scale
       if (size_y && pix) {
         return (size_y * pix) / 3600
+      } else return 1
+    },
+    // Getting height for 'Full' zoom selection
+    getFullHeight () {
+      const size_x = this.camera_size_x
+      const pix = this.pixel_scale
+      if (size_x && pix) {
+        return (size_x * pix) / 3600
       } else return 1
     },
 

--- a/src/store/modules/project_params.js
+++ b/src/store/modules/project_params.js
@@ -51,7 +51,7 @@ const state = {
   max_ha: 4, // decimal hours
   min_zenith_dist: 0, // degrees
   max_night_duration: 6, // hours
-  max_airmass: 3.0,
+  max_airmass: 3.00,
   lunar_dist_min: 30, // deg
   lunar_phase_max: 60, // %
   frequent_autofocus: false,
@@ -226,7 +226,7 @@ const actions = {
     commit('max_ha', 4) // decimal hrs
     commit('min_zenith_dist', 0) // deg
     commit('max_night_duration', 6) // hours
-    commit('max_airmass', 2.0)
+    commit('max_airmass', 2.00)
     commit('lunar_dist_min', 30) // deg
     commit('lunar_phase_max', 60) // %
     commit('frequent_autofocus', false)


### PR DESCRIPTION
## FIX: >Project values

**Background:**
Wayne[ made a request](https://lcogt.slack.com/archives/CLAQ9U79B/p1716659993681929) to switch the values for `width` and `height` under the `Projects` tab and allow for up to 2 decimal places for `airmass` under `Advanced Options`.

**Implementation:**
For the first part of the request, I just changed `camera_size_x` for `camera_size_y` when we get `width` and the opposite for when we get `height`. 
Then for the second part of the request, I added a method that rounds max airmass called `roundMaxAirmass` to the nearest 2nd decimal and it's invoked in the `blur` event of the `Max Airmass` field. _**That being said**_, there is a `warn.max_airmass` that is immediately triggered but it goes away if the user clicks on the field again. Not sure if we should get rid of the warning altogether but it works without if the user enters up to 2 decimal places.

### VISUALS
**Screenshot of width now being the greater value**
<img width="1102" alt="Screenshot 2024-05-28 at 2 13 17 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/709a3a84-22f7-4a8a-b15d-6883e98bca17">


**Screen recording of user entering more than 2 decimal places, warning appears, then it goes away again**

https://github.com/LCOGT/ptr_ui/assets/54489472/d8f7a4a7-c229-4cc4-8e4b-897dde75d9a3



