### PR TITLE
fixed duplicate moons

### DIFF
--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -669,6 +669,9 @@ export default {
     },
 
     dayRender (dayRenderInfo) {
+      if (this.fullCalendarApi?.view?.type === 'timeGridWeek') {
+        this.addUTCTimeColumn()
+      }
       try {
         const date = moment(dayRenderInfo.date).tz(this.fc_timeZone)
         const moon_phase = getMoonPhaseDays(

--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -668,14 +668,8 @@ export default {
       this.fullCalendarApi.refetchEvents()
     },
 
-    // Display moon phase icons in the calendar
     dayRender (dayRenderInfo) {
-      // Check if the current view is week view
-      if (this.fullCalendarApi?.view?.type === 'timeGridWeek') {
-        this.addUTCTimeColumn()
-      }
-
-      try { // ignore errors from the timezone not being loaded yet.
+      try {
         const date = moment(dayRenderInfo.date).tz(this.fc_timeZone)
         const moon_phase = getMoonPhaseDays(
           date.year(),
@@ -683,11 +677,37 @@ export default {
           date.date())
 
         if (moon_phase) {
-          dayRenderInfo.el.innerHTML = `<i class="moon-icon mdi \
-              mdi-moon-${moon_phase.name}" aria-hidden="true"></i>`
+          const headerCell = document.querySelector(`.fc-day[data-date="${date.format('YYYY-MM-DD')}"]`)
+
+          if (headerCell) {
+            // Create a unique data attribute for the moon icon based on the date
+            const moonIconDataAttr = `moon-icon-${date.format('YYYY-MM-DD')}`
+
+            // Check if the moon icon has already been added to this specific header cell
+            if (!headerCell.querySelector(`[data-moon-icon="${moonIconDataAttr}"]`)) {
+              console.log('Adding moon icon to header cell:', headerCell)
+
+              // Remove any existing moon icons in this cell
+              const existingMoonIcons = headerCell.querySelectorAll('.moon-icon')
+              existingMoonIcons.forEach(icon => icon.remove())
+
+              // Add new moon icon
+              const moonIcon = document.createElement('i')
+              moonIcon.className = `moon-icon mdi mdi-moon-${moon_phase.name}`
+              moonIcon.setAttribute('aria-hidden', 'true')
+              moonIcon.setAttribute('data-moon-icon', moonIconDataAttr)
+
+              // Append the moon icon to the header cell content
+              headerCell.appendChild(moonIcon)
+
+              // Adjust the style to place it below the date
+              moonIcon.style.display = 'block'
+              moonIcon.style.marginTop = '5px'
+            }
+          }
         }
-      } catch {
-        console.warn('dayRender waiting for valid timezone.')
+      } catch (error) {
+        console.warn('dayRender waiting for valid timezone.', error)
       }
     },
 

--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -685,8 +685,6 @@ export default {
 
             // Check if the moon icon has already been added to this specific header cell
             if (!headerCell.querySelector(`[data-moon-icon="${moonIconDataAttr}"]`)) {
-              console.log('Adding moon icon to header cell:', headerCell)
-
               // Remove any existing moon icons in this cell
               const existingMoonIcons = headerCell.querySelectorAll('.moon-icon')
               existingMoonIcons.forEach(icon => icon.remove())


### PR DESCRIPTION
## FIX: Duplicate moons 

**Background:**
Wayne brought up the issue where the lunar bands weren't showing up (fixed now) and the moon icons were duplicated.

**Implementation:**
In the function `dayRender`, I've added a query selector that finds the header cell (i.e. where we actually want the moon icons to render). Then if that exists, I create `moonIconDataAttr` which is unique to each date. Then I look for other existing moon icons and remove them. Lastly, I create the moon icon and append it to the header cell. 

### VISUALS
**Before: duplicate moons**
<img width="1097" alt="Screenshot 2024-06-28 at 2 17 05 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/9afa941a-2304-4daf-b76e-4c6be3340c0e">

**After: one moon per column**
<img width="826" alt="Screenshot 2024-06-28 at 2 16 34 PM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/d6a83abe-4193-472e-922b-d0a74602ea66">
