### PR TITLE
changed a of rgba, changed width of bar, and moved z-index of weather…

### DIFF
--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -1226,7 +1226,7 @@ $moon-info-z-index: 20; // this should be above all other events
 $now-indicator-z-index: 19;
 $moon-icon-z-index: 18;
 $forecast-z-index: 16; // this should be above the moon
-$moon-z-index: 0;
+$moon-z-index: 15;
 $observing-start-end-z-index: 15;
 $sky-darkness-z-index: 15;
 

--- a/src/components/calendar/TheCalendar.vue
+++ b/src/components/calendar/TheCalendar.vue
@@ -1096,7 +1096,7 @@ export default {
           start: new Date(moon.rise),
           end: new Date(moon.set),
           rendering: 'background',
-          backgroundColor: rgba_from_illumination(moon.illumination, 235),
+          backgroundColor: rgba_from_illumination(moon.illumination, 255),
           borderColor: '#aaaaaa',
           id: 'fc-custom-moon-indicator',
           classNames: ['fc-moon-indicator'],
@@ -1218,7 +1218,7 @@ export default {
 @import "@/style/buefy-styles.scss";
 @import "@/style/_variables.scss";
 
-$moon-width: 16px;
+$moon-width: 20px;
 
 $event-left-margin: 4px;
 
@@ -1226,7 +1226,7 @@ $moon-info-z-index: 20; // this should be above all other events
 $now-indicator-z-index: 19;
 $moon-icon-z-index: 18;
 $forecast-z-index: 16; // this should be above the moon
-$moon-z-index: 15;
+$moon-z-index: 0;
 $observing-start-end-z-index: 15;
 $sky-darkness-z-index: 15;
 
@@ -1380,6 +1380,7 @@ These times are obtained from the events in the site config */
 .fc-moon-indicator {
   z-index: $moon-z-index;
   width: $moon-width;
+  opacity: 0.4;
   transition: 0.2s;
 }
 .fc-moon-indicator:hover {
@@ -1391,7 +1392,7 @@ These times are obtained from the events in the site config */
 .fc-forecast-event {
   $background-opacity: 0;
   $border-width: $forecast-width;
-  // z-index: $forecast-z-index !important;
+  z-index: $forecast-z-index !important;
   opacity: 1;
   background-color: rgba(0,0,0,0);
   width: 0;

--- a/src/utils/calendar_utils.js
+++ b/src/utils/calendar_utils.js
@@ -151,7 +151,7 @@ const getMoonPhaseDays = (year, month, day) => {
  * @returns {string}: css value, something like 'rgba(255,255,255,0.5)'
  */
 const rgba_from_illumination = (illum, peak) => {
-  const alpha = 0.1 + (0.9 * illum) // should have minimum opacity of 0.1
+  const alpha = 0.1 + (0.9 * illum) + 1
   return `rgba(${peak},${peak},${peak},${alpha})`
 }
 


### PR DESCRIPTION
## QUICK UI FIX: Width and opacity of lunar band and position of weather band

**Background:**
Wayne requested the lunar band to be a tad wider and more opaque and to have the weather band on top of the lunar band. 

**Implementation:**
The function `rgba_from_illumination` determines the color and the alpha (i.e. opacity) of the moon band. The alpha was too low so I added `1` to it to make it more opaque. I changed the width of the moon to be `20px`. And uncommented this line `z-index: $forecast-z-index !important` to bring the weather band on top of the lunar band


### VISUALS:
**Before**
<img width="1102" alt="Screenshot 2024-07-01 at 11 04 16 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/b523af9c-3013-4d41-b86c-cf823f91cbef">

**After**
<img width="1119" alt="Screenshot 2024-07-01 at 11 04 22 AM" src="https://github.com/LCOGT/ptr_ui/assets/54489472/c2342132-de5d-47ff-a56a-6eef9860dc98">
