### PR TITLE
UI Requests: project inputs, generic filters, observing mode

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -381,7 +381,7 @@ export default {
         'RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'
       ],
       generic_filter_list: [
-        'Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo'
+        'Lum', 'Red', 'Green', 'Blue', 'UV', 'IR Block', 'DUO', 'NIR', 'Exo', 'HA', 'O3', 'S2'
       ]
     }
   },

--- a/src/components/InstrumentControls/Enclosure.vue
+++ b/src/components/InstrumentControls/Enclosure.vue
@@ -88,10 +88,13 @@
           size="is-small"
         >
           <option value="active">
-            Active
+            Online
+          </option>
+          <option value="engineering">
+            Engineering
           </option>
           <option value="inactive">
-            Inactive
+            Offline
           </option>
         </b-select>
         <p class="control">
@@ -443,7 +446,7 @@ export default {
       skyTempLimitWarningLevel: 80,
       skyTempLimitDangerLevel: 90,
       lowestAmbientTemp: '',
-      highestAmbientTemp: '',
+      highestAmbientTemp: ''
     }
   },
   methods: {
@@ -453,7 +456,7 @@ export default {
           force_roof_state: val
         }
       )
-    },
+    }
   },
 
   computed: {

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -947,8 +947,8 @@ export default {
       generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo', 'HA', 'O3', 'S2'],
       quick_stacks_filter_list: ['RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'],
       generic_camera_areas: [
-        'Mosaic deg.', 'Mosaic arcmin.', 'Big sq.', 'Full',
-        'Small sq.', '1.5X', '2X', '3X', '4X', '6X', '8X', '12X', '16X'
+        'Mosaic arcmin.', 'Mosaic deg.', '30\'x30\'', 'Small sq.', 'Full', 'Big sq.',
+        '1.5X', '2X', '3X', '4X', '6X', '8X', '12X', '16X', 'Planet'
       ],
       minDegrees: 0.0,
       maxDegrees: this.getMosaicLimits(),

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -944,7 +944,7 @@ export default {
       // Pos 10 to 80, including two single quotes containing the value.
       // This is used to limit the max length of the project note.
       max_fits_header_length: 68,
-      generic_filter_list: ['Lum', 'Blue', 'Green', 'Red', 'NIR', 'Exo', 'HA', 'O3', 'S2'],
+      generic_filter_list: ['Lum', 'Red', 'Green', 'Blue', 'UV', 'IR Block', 'DUO', 'NIR', 'Exo', 'HA', 'O3', 'S2'],
       quick_stacks_filter_list: ['RGB irg', 'LRGB wirg', 'UBV ugr', 'O3HaS2'],
       generic_camera_areas: [
         'Mosaic arcmin.', 'Mosaic deg.', '30\'x30\'', 'Small sq.', 'Full', 'Big sq.',

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -1303,7 +1303,7 @@ export default {
     },
     // This function is used to dynamically change classes of width and height so that they display the appropriate symbol depending on the zoom selection
     getSymbol (zoom) {
-      if (zoom === 'Mosaic arcmin.') {
+      if (['Mosaic arcmin.', '30\'x30\''].includes(zoom)) {
         return 'arcmin-input'
       } else return 'degree-input'
     },
@@ -1402,7 +1402,9 @@ export default {
       } else if (zoom === 'Big sq.') {
         widthVal = this.getBigSquareValues()
       } else if (zoom === 'Mosaic arcmin.' || zoom === 'Mosaic deg.') {
-        widthVal = 0.0
+        widthVal = 0
+      } else if (zoom == '30\'x30\'') {
+        widthVal = 30
       }
       return widthVal
     },
@@ -1436,7 +1438,9 @@ export default {
       } else if (zoom === 'Big sq.') {
         heightVal = this.getBigSquareValues()
       } else if (zoom === 'Mosaic arcmin.' || zoom === 'Mosaic deg.') {
-        heightVal = 0.0
+        heightVal = 0
+      } else if (zoom == '30\'x30\'') {
+        heightVal = 30
       }
       return heightVal
     }

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -341,7 +341,7 @@
                 </option>
                 <option
                   v-for="filter in project_filter_list"
-                  :key="filter"
+                  :key="'site-'+filter"
                   :value="filter"
                 >
                   {{ filter }}
@@ -354,7 +354,7 @@
                 </option>
                 <option
                   v-for="filter in generic_filter_list"
-                  :key="filter"
+                  :key="'generic-'+filter"
                   :value="filter"
                 >
                   {{ filter }}
@@ -367,7 +367,7 @@
                 </option>
                 <option
                   v-for="filter in quick_stacks_filter_list"
-                  :key="filter"
+                  :key="'quickstacks-'+filter"
                   :value="filter"
                 >
                   {{ filter }}

--- a/src/components/projects/CreateProjectForm.vue
+++ b/src/components/projects/CreateProjectForm.vue
@@ -227,7 +227,7 @@
           <b-field
             :type="{'is-warning': warn.targetRA}"
             label="RA"
-            style="width: 230px;"
+            style="width: 260px;"
           >
             <template #message>
               <div v-if="warn.targetRA">
@@ -243,7 +243,7 @@
           <b-field
             :type="{'is-warning': warn.targetDec}"
             label="Dec"
-            style="width: 230px;"
+            style="width: 260px;"
           >
             <template #message>
               <div v-if="warn.targetDec">

--- a/src/components/sitepages/SiteProjects.vue
+++ b/src/components/sitepages/SiteProjects.vue
@@ -59,7 +59,7 @@ export default {
       siteTime: '-',
       utcTime: '-',
 
-      project_to_load: '',
+      project_to_load: {},
       inspectModalActive: false
     }
   },

--- a/src/store/modules/sitestatus/getters/wema_settings_getters.js
+++ b/src/store/modules/sitestatus/getters/wema_settings_getters.js
@@ -29,9 +29,19 @@ const owmActive = (state, getters) => {
 }
 
 const observingMode = (state, getters) => {
+  let observingModeDisplay = state.wema_settings.observing_mode ?? 'n/a'
+
+  // Keep 'active' and 'inactive' as underlying values, but show 'Online' or 'Offline' to the user instead
+  // per Wayne's request
+  if (observingModeDisplay == 'active') {
+    observingModeDisplay = 'Online'
+  } else if (observingModeDisplay == 'inactive') {
+    observingModeDisplay = 'Offline'
+  }
+
   return {
     name: 'Observing Mode',
-    val: state.wema_settings.observing_mode ?? 'n/a',
+    val: observingModeDisplay,
     is_stale: isStale(state, getters)
   }
 }


### PR DESCRIPTION
Adding some changes on Wayne's request:
- Update the values in the projects->exposures->zoom select to be:
	- mosaic amin
	- mosaic deg
	- 30’x30’ 	*NEW
	- small sq. 	*reordered
	- full
	- big sq. 		*reordered
	- <the rest>
	- planet 		*NEW

- Generic filters: after lrgb, add ‘UV’, ‘IR Block’, DUO’ 

- Expand RA/Dec inputs in projects so they don't truncate the values in sexagesimal form

- Modify 'Observing Mode' in the enclosure control tab:
	- add new val 'engineering'
	- change display of 'active' to 'Online'
	- change display of 'inactive' to 'Offline'