### PR TITLE
Airmass / Altitude boundary display in skymap

### DIFF
--- a/src/components/FormElements/AirmassAltitudeInput.vue
+++ b/src/components/FormElements/AirmassAltitudeInput.vue
@@ -1,0 +1,135 @@
+
+<template>
+  <div>
+    <b-field
+      :type="hasError ? 'is-danger' : 'is-dark'"
+      :message="errorMessage"
+      :size="size"
+    >
+      <b-input
+        v-model="localVal"
+        :size="size"
+        lazy
+        :disabled="disabled"
+        style="width: 100%;"
+      />
+      <b-select
+        v-model="units"
+        :size="size"
+        :disabled="disabled"
+      >
+        <option value="alt">
+          altitude [deg]
+        </option>
+        <option value="airmass">
+          airmass
+        </option>
+      </b-select>
+    </b-field>
+  </div>
+</template>
+
+<script>
+export default {
+  props: [
+    'value', // altitude (in degrees) fed from the parent component
+    'size',
+    'disabled'
+  ],
+  data () {
+    return {
+      localVal: this.value, // the text input should match the altitude fed in from the parent component
+      airmassToAltitudeLookup: {},
+      units: 'alt',
+      hasError: false,
+      errorMessage: ''
+    }
+  },
+  watch: {
+    value (newVal) {
+      // If the parent component updates the prop that is sent in to this component,
+      // update the local value in terms of the selected units
+      if (newVal == null || newVal === '') {
+        this.localVal = newVal
+      } else {
+        this.localVal = this.convertToSelectedUnits(newVal)
+      }
+    },
+    localVal (newVal) {
+      // When the value in the input field changes, validate it and emit it back to the parent component
+      if (newVal != null && newVal !== '') {
+        this.validateAndEmit(newVal)
+      }
+    },
+    units (newVal) {
+      // When the user switches between altitude and airmass units, recompute the equivalent value to display locally
+      if (this.value == null || this.value === '') return
+      this.localVal = this.convertToSelectedUnits(this.value)
+    }
+  },
+  methods: {
+    roundToPrecision (float, decimals) {
+      const decimalMover = 10 ** decimals
+      return Math.round(decimalMover * float) / decimalMover
+    },
+    altitudeToAirmass (alt) {
+      // input altitude should be decimal degrees from horizon
+      const precision = 2 // how many decimal places to use for result
+
+      const altFromZenith = 90 - alt
+      const altRad = altFromZenith * Math.PI / 180
+      const airmass = this.roundToPrecision(1 / Math.cos(altRad), precision)
+      // Cache results for reverse calculation (avoid floating point equality errors)
+      this.airmassToAltitudeLookup[airmass] = alt
+      return airmass
+    },
+    airmassToAltitude (airmass) {
+      // return altitude in decimal degrees from horizon
+      const precision = 1 // how many decimal places to use for result
+
+      // Try to use a cached result first
+      if (airmass in this.airmassToAltitudeLookup) {
+        console.log('returning altitude from lookup: ', this.airmassToAltitudeLookup[airmass])
+        return this.airmassToAltitudeLookup[airmass]
+      }
+
+      // otherwise, do the computation
+      const altFromZenithRad = Math.acos(1 / airmass)
+      const altFromZenithDeg = altFromZenithRad * 180 / Math.PI
+      const altFromHorizonDeg = this.roundToPrecision(90 - altFromZenithDeg, precision)
+      return altFromHorizonDeg
+    },
+    convertToSelectedUnits (val) {
+      if (this.units == 'airmass') {
+        return this.altitudeToAirmass(val)
+      } else {
+        return val
+      }
+    },
+    validateAndEmit (value) {
+      this.hasError = false
+      this.errorMessage = ''
+      try {
+        // Validate altitude input
+        if (this.units === 'alt') {
+          if (isNaN(Number(value)) || Number(value) < 0 || Number(value) > 90) {
+            throw new RangeError('Must be between 0 and 90 degrees')
+          }
+          this.$emit('input', Number(value))
+        // Validate airmass input
+        } else if (this.units === 'airmass') {
+          console.log('airmass: ', value)
+          if (isNaN(Number(value)) || Number(value) < 0) {
+            throw new RangeError('Must be a positive number')
+          }
+          // Since the component "speaks" only in altitude (degrees), convert the airmass before emitting
+          this.$emit('input', this.airmassToAltitude(value))
+        }
+      } catch (e) {
+        this.hasError = true
+        this.errorMessage = e.message
+      }
+    }
+  }
+}
+</script>

--- a/src/components/FormElements/AirmassAltitudeInput.vue
+++ b/src/components/FormElements/AirmassAltitudeInput.vue
@@ -74,7 +74,7 @@ export default {
     },
     altitudeToAirmass (alt) {
       // input altitude should be decimal degrees from horizon
-      const precision = 2 // how many decimal places to use for result
+      const precision = 3 // how many decimal places to use for result
 
       const altFromZenith = 90 - alt
       const altRad = altFromZenith * Math.PI / 180
@@ -84,19 +84,15 @@ export default {
       return airmass
     },
     airmassToAltitude (airmass) {
-      // return altitude in decimal degrees from horizon
-      const precision = 1 // how many decimal places to use for result
-
       // Try to use a cached result first
       if (airmass in this.airmassToAltitudeLookup) {
-        console.log('returning altitude from lookup: ', this.airmassToAltitudeLookup[airmass])
         return this.airmassToAltitudeLookup[airmass]
       }
 
       // otherwise, do the computation
       const altFromZenithRad = Math.acos(1 / airmass)
       const altFromZenithDeg = altFromZenithRad * 180 / Math.PI
-      const altFromHorizonDeg = this.roundToPrecision(90 - altFromZenithDeg, precision)
+      const altFromHorizonDeg = 90 - altFromZenithDeg
       return altFromHorizonDeg
     },
     convertToSelectedUnits (val) {
@@ -118,9 +114,8 @@ export default {
           this.$emit('input', Number(value))
         // Validate airmass input
         } else if (this.units === 'airmass') {
-          console.log('airmass: ', value)
-          if (isNaN(Number(value)) || Number(value) < 0) {
-            throw new RangeError('Must be a positive number')
+          if (isNaN(Number(value)) || Number(value) < 1) {
+            throw new RangeError('Airmass is a positive number >= 1')
           }
           // Since the component "speaks" only in altitude (degrees), convert the airmass before emitting
           this.$emit('input', this.airmassToAltitude(value))

--- a/src/components/celestialmap/TheSkyChart.vue
+++ b/src/components/celestialmap/TheSkyChart.vue
@@ -60,10 +60,6 @@ export default {
       type: Boolean,
       default: true
     },
-    showDaylight: {
-      type: Boolean,
-      default: false
-    },
     showMilkyWay: {
       type: Boolean,
       default: true
@@ -112,6 +108,15 @@ export default {
     openClusterMagMax: {
       type: Number,
       default: 0
+    },
+
+    showAirmassCircle: {
+      type: Boolean,
+      default: true
+    },
+    degAboveHorizon: {
+      type: Number,
+      default: 30
     },
 
     use_custom_date_location: {
@@ -184,6 +189,10 @@ export default {
         show: this.showOpenClusters,
         minMagnitude: this.openClusterMagMin,
         maxMagnitude: this.openClusterMagMax
+      },
+      airmassCircle: {
+        show: this.showAirmassCircle,
+        degAboveHorizon: this.degAboveHorizon
       }
     }
 
@@ -374,9 +383,6 @@ export default {
     showPlanets () {
       Celestial.reload({ planets: { which: this.planetsList } })
     },
-    showDaylight () {
-      Celestial.apply({ daylight: { show: this.showDaylight } })
-    },
     showMilkyWay () {
       Celestial.apply({ mw: { show: this.showMilkyWay } })
     },
@@ -420,7 +426,16 @@ export default {
     openClusterMagMax () {
       Celestial.customData.openClusters.maxMagnitude = this.openClusterMagMax
       Celestial.redraw()
+    },
+    showAirmassCircle () {
+      Celestial.customData.airmassCircle.show = this.showAirmassCircle
+      Celestial.redraw()
+    },
+    degAboveHorizon () {
+      Celestial.customData.airmassCircle.degAboveHorizon = this.degAboveHorizon
+      Celestial.redraw()
     }
+
   },
 
   computed: {

--- a/src/components/celestialmap/TheSkyChart.vue
+++ b/src/components/celestialmap/TheSkyChart.vue
@@ -151,6 +151,7 @@ export default {
 
       // Whether or not the mouse is hovering over the sky part of the map.
       mouse_in_sky: false,
+      airmassCircleIsHovered: false,
 
       resize_observer: ''
     }
@@ -192,7 +193,8 @@ export default {
       },
       airmassCircle: {
         show: this.showAirmassCircle,
-        degAboveHorizon: this.degAboveHorizon
+        degAboveHorizon: this.degAboveHorizon,
+        isHovered: this.airmassCircleIsHovered
       }
     }
 
@@ -269,6 +271,15 @@ export default {
     handle_mouseover (e) { // Determine whether the mouse is inside the map or not
       const map_coords = Celestial.mapProjection.invert(e)
       this.mouse_in_sky = !!Celestial.clip(map_coords) // !! converts 0 or 1 to boolean
+
+      // Check and store the state of whether the user is hovering over the airmass circle
+      const zenith = Celestial.zenith()
+      const zenithXY = Celestial.mapProjection(zenith)
+      const horizonXY = Celestial.mapProjection([zenith[0], zenith[1] - (90 - this.degAboveHorizon)]) // get a point on the horizon
+      const circleRadius = Math.abs(zenithXY[1] - horizonXY[1])
+      const radiusToCenter = Math.sqrt((e[0] - zenithXY[0]) ** 2 + (e[1] - zenithXY[1]) ** 2)
+      const tolerance = 7 // how many pixels away should register as a hover event
+      this.airmassCircleIsHovered = (tolerance >= Math.abs(radiusToCenter - circleRadius))
     },
 
     rotate () {
@@ -433,6 +444,10 @@ export default {
     },
     degAboveHorizon () {
       Celestial.customData.airmassCircle.degAboveHorizon = this.degAboveHorizon
+      Celestial.redraw()
+    },
+    airmassCircleIsHovered () {
+      Celestial.customData.airmassCircle.isHovered = this.airmassCircleIsHovered
       Celestial.redraw()
     }
 

--- a/src/components/celestialmap/add_custom_data.js
+++ b/src/components/celestialmap/add_custom_data.js
@@ -49,6 +49,40 @@ const distance = (p1, p2) => {
   return Math.sqrt(d1 * d1 + d2 * d2)
 }
 
+const drawAirmassCircle = Celestial => {
+  // Draw a circle centered at the zenith with a radius that extends to a certain airmass (altitude) above horizon
+  if (!Celestial.customData.airmassCircle?.show) return
+
+  const color = 'yellow'
+  const lineWidth = 0.5
+
+  const degreesAboveHorizon = Celestial.customData.airmassCircle.degAboveHorizon
+  const degreesBelowZenith = 90 - degreesAboveHorizon
+
+  const zenith = Celestial.zenith() // zenith ra/dec (degrees)
+  const zenithXY = Celestial.mapProjection(zenith) // convert to xy pixel coords
+
+  // Don't show if zenith is [0,0]
+  // This is a simple fix to avoid rendering the circle before the map has positioned itself.
+  // Not worth worrying about the rare and brief moments when the zenith actually is [0,0].
+  // Maybe there is a more elegant solution but this sky chart is impossible to figure out sometimes.
+  if (zenith[0] == 0 && zenith[1] == 0) return
+
+  const horizon = [zenith[0], zenith[1] - degreesBelowZenith] // get a point on the horizon
+  const horizonXY = Celestial.mapProjection(horizon) // convert to xy pixel coords
+
+  // the radius of our circle is the difference between the y coordinate for the horizon point and zenith
+  const radiusPix = Math.abs(zenithXY[1] - horizonXY[1])
+
+  // draw the circle
+  Celestial.context.strokeStyle = color
+  Celestial.context.lineWidth = lineWidth
+  Celestial.context.beginPath()
+  Celestial.context.arc(zenithXY[0], zenithXY[1], radiusPix, 0, 2 * Math.PI)
+  Celestial.context.closePath()
+  Celestial.context.stroke()
+}
+
 const draw_star = (Celestial, quadtree, styles, starbase, starexp, d) => {
   if (!Celestial.customData.stars.show) return
   if (d.properties.mag > Celestial.customData.stars.minMagnitude) return
@@ -229,7 +263,6 @@ const add_custom_data = (Celestial, base_config, data_list) => {
           .data(sky_objects.features)
           .enter().append('path')
           .attr('class', 'custom_obj')
-        Celestial.redraw()
       },
       redraw: () => {
         // The quadtree is used to avoid rendering object names that overlap
@@ -255,6 +288,7 @@ const add_custom_data = (Celestial, base_config, data_list) => {
             }
           }
         })
+        drawAirmassCircle(Celestial)
       }
     })
   };

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -363,7 +363,7 @@
               <div class="horizontal-separator" />
 
               <div class="object-filter-label">
-                Horizon Circle
+                Airmass Boundary
                 <b-tooltip
                   type="is-dark"
                   size="is-small"

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -363,11 +363,11 @@
               <div class="horizontal-separator" />
 
               <div class="object-filter-label">
-                Airmass Boundary
+                Airmass/Altitude Boundary
                 <b-tooltip
                   type="is-dark"
                   size="is-small"
-                  label="Mark useful region by airmass or altitude"
+                  label="Denote a useful region with a specific airmass or altitude"
                 >
                   <b-icon
                     size="is-small"

--- a/src/components/sitepages/SiteTargets.vue
+++ b/src/components/sitepages/SiteTargets.vue
@@ -34,7 +34,6 @@
 
           :show-moon="showMoon"
           :show-sun="showSun"
-          :show-daylight="showDaylight"
           :show-milky-way="showMilkyWay"
           :show-planets="showPlanets"
 
@@ -48,6 +47,9 @@
           :globular-cluster-mag-max="globularClusterMagMax"
           :open-cluster-mag-min="openClusterMagMin"
           :open-cluster-mag-max="openClusterMagMax"
+
+          :show-airmass-circle="showAirmassCircle"
+          :deg-above-horizon="degAboveHorizon"
 
           :use_custom_date_location="use_custom_date_location"
           :show_live_chart="isLiveSkyDisplay"
@@ -176,7 +178,7 @@
                   label="max mag"
                 >
                   <b-input
-                    v-model="starMagMax"
+                    v-model.number="starMagMax"
                     style="width: 80px;"
                     size="is-small"
                     label="max mag"
@@ -190,7 +192,7 @@
                   label="min mag"
                 >
                   <b-input
-                    v-model="starMagMin"
+                    v-model.number="starMagMin"
                     style="width: 80px;"
                     size="is-small"
                     label="min mag"
@@ -215,7 +217,7 @@
                   label="max mag"
                 >
                   <b-input
-                    v-model="galaxyMagMax"
+                    v-model.number="galaxyMagMax"
                     style="width: 80px;"
                     size="is-small"
                     label="max mag"
@@ -229,7 +231,7 @@
                   label="min mag"
                 >
                   <b-input
-                    v-model="galaxyMagMin"
+                    v-model.number="galaxyMagMin"
                     style="width: 80px;"
                     size="is-small"
                     label="min mag"
@@ -254,7 +256,7 @@
                   label="max mag"
                 >
                   <b-input
-                    v-model="nebulaMagMax"
+                    v-model.number="nebulaMagMax"
                     style="width: 80px;"
                     size="is-small"
                     label="max mag"
@@ -268,7 +270,7 @@
                   label="min mag"
                 >
                   <b-input
-                    v-model="nebulaMagMin"
+                    v-model.number="nebulaMagMin"
                     style="width: 80px;"
                     size="is-small"
                     label="min mag"
@@ -293,7 +295,7 @@
                   label="max mag"
                 >
                   <b-input
-                    v-model="globularClusterMagMax"
+                    v-model.number="globularClusterMagMax"
                     style="width: 80px;"
                     size="is-small"
                     label="max mag"
@@ -307,7 +309,7 @@
                   label="min mag"
                 >
                   <b-input
-                    v-model="globularClusterMagMin"
+                    v-model.number="globularClusterMagMin"
                     style="width: 80px;"
                     size="is-small"
                     label="min mag"
@@ -332,7 +334,7 @@
                   label="max mag"
                 >
                   <b-input
-                    v-model="openClusterMagMax"
+                    v-model.number="openClusterMagMax"
                     style="width: 80px;"
                     size="is-small"
                     label="max mag"
@@ -346,7 +348,7 @@
                   label="min mag"
                 >
                   <b-input
-                    v-model="openClusterMagMin"
+                    v-model.number="openClusterMagMin"
                     style="width: 80px;"
                     size="is-small"
                     label="min mag"
@@ -360,13 +362,38 @@
 
               <div class="horizontal-separator" />
 
-              <div style="display: flex; justify-content: space-between;">
-                <b-field label="daylight">
-                  <b-switch
-                    v-model="showDaylight"
-                    style="margin-bottom: 0.75rem;"
+              <div class="object-filter-label">
+                Horizon Circle
+                <b-tooltip
+                  type="is-dark"
+                  size="is-small"
+                  label="Mark useful region by airmass or altitude"
+                >
+                  <b-icon
+                    size="is-small"
+                    icon="help-circle-outline"
+                  />
+                </b-tooltip>
+              </div>
+              <div class="object-filter-group">
+                <b-switch
+                  v-model="showAirmassCircle"
+                  style="margin-bottom: 0.75rem;"
+                  :rounded="false"
+                />
+                <b-field>
+                  <AirmassAltitudeInput
+                    v-model.number="degAboveHorizon"
+                    size="is-small"
+                    style="width: 200px;"
                   />
                 </b-field>
+                <b-field />
+              </div>
+
+              <div class="horizontal-separator" />
+
+              <div style="display: flex; justify-content: space-between;">
                 <b-field label="moon">
                   <b-switch
                     v-model="showMoon"
@@ -586,6 +613,7 @@ import { mapGetters } from 'vuex'
 import TheSkyChart from '@/components/celestialmap/TheSkyChart'
 import DateTimeLocationPicker from '@/components/celestialmap/DateTimeLocationPicker'
 import CommandTabsAccordion from '@/components/CommandTabsAccordion'
+import AirmassAltitudeInput from '@/components/FormElements/AirmassAltitudeInput'
 // import Celestial from '@/components/celestialmap/celestial'
 import celestial from 'd3-celestial'
 
@@ -604,6 +632,7 @@ export default {
   components: {
     TheSkyChart,
     CommandTabsAccordion,
+    AirmassAltitudeInput,
     DateTimeLocationPicker,
     TargetCard
   },
@@ -631,7 +660,6 @@ export default {
       showOpenClusters: true,
       showMoon: true,
       showSun: true,
-      showDaylight: false,
       showMilkyWay: true,
       showPlanets: true,
 
@@ -645,6 +673,9 @@ export default {
       globularClusterMagMax: 0,
       openClusterMagMin: 10,
       openClusterMagMax: 0,
+
+      showAirmassCircle: true,
+      degAboveHorizon: 30,
 
       use_custom_date_location: false,
       skychart_date: new Date(),
@@ -796,10 +827,6 @@ export default {
         Celestial.resize({ width })
         document.getElementsByClassName('skychart-center')[0].style.width = height + 'px'
       }
-    },
-
-    toggle_daylight () {
-      Celestial.apply({ daylight: { show: true } })
     },
 
     update_skychart_time_and_place (time_and_place) {


### PR DESCRIPTION
This change adds a feature to the skymap requested by Wayne: a yellow circle at a specific altitude or airmass that can be configured. 
<img width="1219" alt="Screenshot 2024-10-01 at 2 26 39 PM" src="https://github.com/user-attachments/assets/bd8b475b-9cd0-4111-b64b-edc6c165cb2e">

The value of altitude or airmass that is displayed can be set by the user
<img width="275" alt="Screenshot 2024-10-01 at 2 27 34 PM" src="https://github.com/user-attachments/assets/75339b68-5747-4be4-9c6d-83ddb16bd599">
<img width="282" alt="Screenshot 2024-10-01 at 2 27 17 PM" src="https://github.com/user-attachments/assets/33976323-5c4d-4d30-b46f-d56cec226af8">

This input component will automatically convert between the two to keep the same circle across changes in units. For example, if the user has  "2" entered with airmass selected and they change the units to altitude, the input will update to "30" and the yellow circle won't change. This conversion becomes less accurate at the extremes. 

Hovering over the yellow circle will display a label showing the altitude at the bottom of the circle.
<img width="137" alt="Screenshot 2024-10-01 at 2 32 06 PM" src="https://github.com/user-attachments/assets/d3bea0ee-e7ec-4c0f-8602-e944cc4b038c">
