### PR TITLE
Add 'cam_note' and 'tel_note' to command payloads

### DIFF
--- a/src/components/InstrumentControls/Camera.vue
+++ b/src/components/InstrumentControls/Camera.vue
@@ -273,10 +273,10 @@
 
     <b-field
       horizontal
-      label="Note"
+      label="Cam Note"
     >
       <b-input
-        v-model="camera_note"
+        v-model="cam_note"
         placeholder="a camera note for the FITS header..."
         type="text"
         min="0"
@@ -432,9 +432,9 @@ export default {
       get () { return this.$store.getters['command_params/camera_areas_selection'] },
       set (val) { this.$store.commit('command_params/camera_areas_selection', val) }
     },
-    camera_note: {
-      get () { return this.$store.getters['command_params/camera_note'] },
-      set (val) { this.$store.commit('command_params/camera_note', val) }
+    cam_note: {
+      get () { return this.$store.getters['command_params/cam_note'] },
+      set (val) { this.$store.commit('command_params/cam_note', val) }
     },
 
     object_name: {

--- a/src/components/InstrumentControls/Telescope.vue
+++ b/src/components/InstrumentControls/Telescope.vue
@@ -154,6 +154,18 @@
       </p>
     </b-field>
     <div class="horizontal-border" />
+    <b-field
+      horizontal
+      label="Tel Note"
+    >
+      <b-input
+        v-model="tel_note"
+        type="text"
+        min="0"
+        max="64"
+        size="is-small"
+      />
+    </b-field>
 
     <!-- "Park" and "Slew To..." button row -->
     <div style="display: flex; gap: 1em;">
@@ -402,6 +414,10 @@ export default {
       set (val) {
         this.$store.commit('command_params/mount_alt', val)
       }
+    },
+    tel_note: {
+      get () { return this.$store.getters['command_params/tel_note'] },
+      set (val) { this.$store.commit('command_params/tel_note', val) }
     },
 
     telescope_selection: {

--- a/src/components/sitepages/SiteObserve.vue
+++ b/src/components/sitepages/SiteObserve.vue
@@ -111,9 +111,9 @@ export default {
       get () { return this.$store.getters['command_params/camera_areas_selection'] },
       set (val) { this.$store.commit('command_params/camera_areas_selection', val) }
     },
-    camera_note: {
-      get () { return this.$store.getters['command_params/camera_note'] },
-      set (val) { this.$store.commit('command_params/camera_note', val) }
+    cam_note: {
+      get () { return this.$store.getters['command_params/cam_note'] },
+      set (val) { this.$store.commit('command_params/cam_note', val) }
     },
     camera_exposure: {
       get () { return this.$store.getters['command_params/camera_exposure'] },

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -304,7 +304,7 @@ export const commands_mixin = {
       'subframeDefinedWithFile',
 
       'camera_areas_selection',
-      'camera_note',
+      'cam_note',
       'object_name',
       'camera_exposure',
       'camera_count',
@@ -451,8 +451,8 @@ export const commands_mixin = {
         username: this.username // from auth0
       }
       // Avoid empty strings (thanks, dynamodb)
-      if (this.camera_note != '') {
-        opt_params.hint = this.camera_note
+      if (this.cam_note != '') {
+        opt_params.hint = this.cam_note
       }
       // if (this.object_name != '') {
       //  opt_params["hint"] = this.object_name

--- a/src/mixins/commands_mixin.js
+++ b/src/mixins/commands_mixin.js
@@ -296,6 +296,7 @@ export const commands_mixin = {
     ...mapGetters('command_params', [
       'telescope_selection',
       'telescope_coordinate_frame',
+      'tel_note',
 
       'smartstackIsActive',
       'subStackIsActive',
@@ -447,16 +448,12 @@ export const commands_mixin = {
         extract: this.camera_extract,
         object_name: this.object_name,
         zoom: this.zoom_options_selection,
-        // object_name: 'test test test',
         username: this.username // from auth0
       }
       // Avoid empty strings (thanks, dynamodb)
       if (this.cam_note != '') {
-        opt_params.hint = this.cam_note
+        opt_params.cam_note = this.cam_note
       }
-      // if (this.object_name != '') {
-      //  opt_params["hint"] = this.object_name
-      // }
 
       // If active, add subframe parameters.
       // Also ignore if active but subframe params specify the whole image [(0,0),(1,1)] (the sum should == 2).
@@ -503,10 +500,8 @@ export const commands_mixin = {
     },
     mount_slew_radec_command () {
       let ra = emptyString(this.mount_ra.toString())
-
       let dec = emptyString(this.mount_dec.toString())
-      const obj = emptyString(this.mount_object.toString())
-      // console.log(ra)
+      const object = emptyString(this.mount_object.toString())
 
       // Convert if RA Decimal Degrees
       if (ra.includes('d')) {
@@ -528,14 +523,14 @@ export const commands_mixin = {
         dec = dec.toFixed(4)
       }
 
-      // if (ra.includes("d") ) {
-      //  ra.replace("d","")
-      //  ra = Number(ra) / 15
-      //  console.log(ra)
-      // }
+      const optional_params = {
+        object,
+        ...(this.tel_note != '' && { tel_note: this.tel_note }) // only add tel_note if it's not an empty string
+      }
+
       return this.base_command('mount', 'go', 'slew to RA/Dec',
         { ra, dec, frame: this.telescope_coordinate_frame },
-        { object: obj }
+        optional_params
       )
     },
     mount_slew_and_center_radec_command () {
@@ -548,19 +543,27 @@ export const commands_mixin = {
     mount_slew_hadec_command () {
       const ha = emptyString(this.mount_ha.toString())
       const dec = emptyString(this.mount_dec.toString())
-      const obj = emptyString(this.mount_object.toString())
+      const object = emptyString(this.mount_object.toString())
+      const optional_params = {
+        object,
+        ...(this.tel_note != '' && { tel_note: this.tel_note }) // only add tel_note if it's not an empty string
+      }
       return this.base_command('mount', 'go', 'slew to HA/Dec',
         { ha, dec, frame: this.telescope_coordinate_frame },
-        { object: obj }
+        optional_params
       )
     },
     mount_slew_azalt_command () {
       const az = emptyString(this.mount_az.toString())
       const alt = emptyString(this.mount_alt.toString())
-      const obj = emptyString(this.mount_object.toString())
+      const object = emptyString(this.mount_object.toString())
+      const optional_params = {
+        object,
+        ...(this.tel_note != '' && { tel_note: this.tel_note }) // only add tel_note if it's not an empty string
+      }
       return this.base_command('mount', 'go', 'slew to az/alt',
         { az, alt, frame: this.telescope_coordinate_frame },
-        { object: obj }
+        optional_params
       )
     },
     mount_slew_near_tycho () {

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -17,6 +17,7 @@ const state = {
 
   telescope_selection: 1, // 1: main telescope, 2: auxiliary telescope
   telescope_coordinate_frame: 'ICRS',
+  tel_note: '',
 
   // Stack parameters
   smartstackIsActive: true,
@@ -64,6 +65,7 @@ const getters = {
   mount_alt: state => state.mount_alt,
   telescope_selection: state => state.telescope_selection,
   telescope_coordinate_frame: state => state.telescope_coordinate_frame,
+  tel_note: state => state.tel_note,
   smartstackIsActive: state => state.smartstackIsActive,
   subStackIsActive: state => state.subStackIsActive,
   subframeIsActive: state => state.subframeIsActive,
@@ -127,6 +129,7 @@ const mutations = {
   mount_object (state, val) { state.mount_object = val },
   telescope_selection (state, val) { state.telescope_selection = val },
   telescope_coordinate_frame (state, val) { state.telescope_coordinate_frame = val },
+  tel_note (state, val) { state.tel_note = val },
   smartstackIsActive (state, val) { state.smartstackIsActive = val },
   subStackIsActive (state, val) { state.subStackIsActive = val },
   subframeIsActive (state, val) { state.subframeIsActive = val },

--- a/src/store/modules/command_params.js
+++ b/src/store/modules/command_params.js
@@ -27,7 +27,7 @@ const state = {
   subframeDefinedWithFile: '',
 
   camera_areas_selection: 'Full',
-  camera_note: '',
+  cam_note: '',
   object_name: '',
   camera_exposure: '1',
   camera_count: 1, // numberinput form requires number, not string. converted to string in expose command.
@@ -69,7 +69,7 @@ const getters = {
   subframeIsActive: state => state.subframeIsActive,
   subframeDefinedWithFile: state => state.subframeDefinedWithFile,
   camera_areas_selection: state => state.camera_areas_selection,
-  camera_note: state => state.camera_note,
+  cam_note: state => state.cam_note,
   object_name: state => state.object_name,
   camera_exposure: state => state.camera_exposure,
   camera_count: state => state.camera_count,
@@ -132,7 +132,7 @@ const mutations = {
   subframeIsActive (state, val) { state.subframeIsActive = val },
   subframeDefinedWithFile (state, val) { state.subframeDefinedWithFile = val },
   camera_areas_selection (state, val) { state.camera_areas_selection = val },
-  camera_note (state, val) { state.camera_note = val },
+  cam_note (state, val) { state.cam_note = val },
   object_name (state, val) { state.object_name = val },
   camera_exposure (state, val) { state.camera_exposure = val },
   camera_count (state, val) { state.camera_count = val },


### PR DESCRIPTION
The cam_note already existed under a different name, so I renamed those occurrences.
I added tel_note to the telescope command tab. 

- cam_note and tel_note are both keys in the optional_params dict that is part of the command payload
- they are not included if the value is an empty string
- tel_note is only considered if the mount command is the ‘go’ command (all green circled buttons in the attached screenshot). tel_note is never included for the other mount commands (red circled buttons in screenshot) like park, slew to flat position, etc.
<img width="370" alt="Screenshot 2024-10-08 at 7 06 30 PM" src="https://github.com/user-attachments/assets/c376228b-2a53-4ec2-b826-bbd6c3c775b8">
